### PR TITLE
PDFGenerator: upgrade to PDFBox 2.0.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>org.apache.pdfbox</groupId>
       <artifactId>pdfbox</artifactId>
-      <version>1.8.2</version>
+      <version>2.0.28</version>
     </dependency>
   </dependencies>
 

--- a/src/main/java/org/bigredbands/mb/controllers/MainController.java
+++ b/src/main/java/org/bigredbands/mb/controllers/MainController.java
@@ -9,7 +9,6 @@ import java.util.HashSet;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.pdfbox.exceptions.COSVisitorException;
 import org.bigredbands.mb.exceptions.DrillXMLException;
 import org.bigredbands.mb.models.CommandPair;
 import org.bigredbands.mb.models.DrillInfo;
@@ -1051,10 +1050,6 @@ public class MainController implements ControllerInterface, SynchronizedControll
             PDFGenerator pdfGenerator = new PDFGenerator();
             try {
                 pdfGenerator.createPDF(drillInfo, file);
-            } catch (COSVisitorException e) {
-                // TODO Auto-generated catch block
-                mainView.displayError("COSVisitorException occurred in generating PDF");
-                e.printStackTrace();
             } catch (IOException e) {
                 // TODO Auto-generated catch block
                 mainView.displayError("IOException occurred in generating PDF");

--- a/src/test/java/org/bigredbands/mb/controllers/PDFGeneratorTest.java
+++ b/src/test/java/org/bigredbands/mb/controllers/PDFGeneratorTest.java
@@ -1,6 +1,5 @@
 package org.bigredbands.mb.controllers;
 
-import java.awt.Dimension;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -8,8 +7,6 @@ import java.util.HashMap;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.apache.pdfbox.exceptions.COSVisitorException;
-import org.bigredbands.mb.controllers.PDFGenerator;
 import org.bigredbands.mb.exceptions.DrillXMLException;
 import org.bigredbands.mb.models.CommandPair;
 import org.bigredbands.mb.models.DrillInfo;
@@ -19,7 +16,6 @@ import org.bigredbands.mb.models.RankPosition;
 import org.junit.Test;
 import org.junit.BeforeClass;
 import org.xml.sax.SAXException;
-import org.bigredbands.mb.views.PdfImage;
 
 public class PDFGeneratorTest {
 
@@ -33,7 +29,7 @@ public class PDFGeneratorTest {
 
     @Test
     public void testCreateBlankPDF() throws ParserConfigurationException,
-            SAXException, IOException, DrillXMLException, COSVisitorException {
+            SAXException, IOException, DrillXMLException {
         // create the expected DrillInfo
         DrillInfo expectedDrillInfo = new DrillInfo();
 
@@ -173,7 +169,7 @@ public class PDFGeneratorTest {
 
     private void testPDFGenerator(DrillInfo expectedDrillInfo, File outputFile)
             throws ParserConfigurationException, SAXException, IOException,
-            DrillXMLException, COSVisitorException {
+            DrillXMLException {
         // generate the pdf
         PDFGenerator generator = new PDFGenerator();
         generator.createPDF(expectedDrillInfo, outputFile);


### PR DESCRIPTION
Closes #4.

Update to the latest released version of PDFBox (v2.0.28). There were a decent amount of breaking changes between versions 1 and 2 (see [migration guide][1]). Those changes are applied here, including:

- remove references to 'COSVisitorException'
- replace 'moveTextPositionByAmount()' with 'newLineAtOffset()'
- replace 'drawString()' with 'showText()'
- replace 'PDJpeg' with 'PDImageXObject'
- replace 'new PDJpeg()' with 'LosslessFactory.createFromImage()'
- replace 'concatenate2CTM()' with 'transform()'
- update to new constructor for 'PDPageContentStream'

Note that this does _not_ change the appearance of the generated PDF; it just brings us up-to-date with the latest version of the library (in preparation for #12).

[1]: https://pdfbox.apache.org/2.0/migration.html