### PR TITLE
DrillInfo: fix #20

### DIFF
--- a/src/main/java/org/bigredbands/mb/controllers/XMLParser.java
+++ b/src/main/java/org/bigredbands/mb/controllers/XMLParser.java
@@ -84,6 +84,15 @@ public class XMLParser {
             addSongConstantToHashMap(drillInfo.getCountsHashMap(), countsPerMeasuresChange.getChildNodes(), XMLConstants.COUNT_PER_MEASURE);
         }
 
+        //create a NodeList of the song-name tags in the document
+        NodeList songNameList = doc.getElementsByTagName(XMLConstants.SONG_NAME);
+
+        //set the song name appropriately
+        if (songNameList.getLength() > 0) {
+            Node songName = songNameList.item(0);
+            drillInfo.setSongName(getTagText(songName));
+        }
+        
         return drillInfo;
     }
 

--- a/src/main/java/org/bigredbands/mb/models/DrillInfo.java
+++ b/src/main/java/org/bigredbands/mb/models/DrillInfo.java
@@ -195,6 +195,17 @@ public class DrillInfo {
         //create the drill tag
         Element drillTag = document.createElement(XMLConstants.DRILL);
 
+        if (songName.length() != 0) {
+            //add the song name
+            //create the song name element
+            Element songTag = document.createElement(XMLConstants.SONG_NAME);
+            drillTag.appendChild(songTag);
+
+            //give the song name a value
+            Text songText = document.createTextNode(songName);
+            songTag.appendChild(songText);
+        }
+        
         //add the tempo changes
         Set<Integer> tempoKeys = tempoHashMap.keySet();
         Iterator<Integer> tempoIterator = tempoKeys.iterator();

--- a/src/main/java/org/bigredbands/mb/models/XMLConstants.java
+++ b/src/main/java/org/bigredbands/mb/models/XMLConstants.java
@@ -32,6 +32,7 @@ public abstract class XMLConstants {
     public static String COMMAND_NAME = "command-name";
 
     //tags associated with song-constants
+    public static String SONG_NAME = "song-name";
     public static String MEASURE_NUMBER = "measure-number";
     public static String TEMPO = "tempo";
     public static String TEMPO_CHANGE  = "tempo-change";

--- a/src/test/java/org/bigredbands/mb/controllers/XMLGeneratorTest.java
+++ b/src/test/java/org/bigredbands/mb/controllers/XMLGeneratorTest.java
@@ -278,6 +278,16 @@ DrillInfo expectedDrillInfo = new DrillInfo();
         testGeneratorAndParser(expectedDrillInfo, new File(outputPath + "10-two-moves-one-rank-song-constants-renamed-command-output.pnd"));
     }
 
+    @Test
+    public void testSongNameChange() throws ParserConfigurationException, SAXException, IOException, DrillXMLException {
+        //create the expected DrillInfo
+        DrillInfo expectedDrillInfo = new DrillInfo();
+        expectedDrillInfo.setSongName("song");
+
+        //test the generator output with the parser
+        testGeneratorAndParser(expectedDrillInfo, new File(outputPath + "12-song-name-change.pnd"));
+    }
+
     private void testGeneratorAndParser(DrillInfo expectedDrillInfo, File outputFile) throws ParserConfigurationException, SAXException, IOException, DrillXMLException {
         //generate the xml
         XMLGenerator generator = new XMLGenerator();

--- a/src/test/java/org/bigredbands/mb/controllers/XMLParserTest.java
+++ b/src/test/java/org/bigredbands/mb/controllers/XMLParserTest.java
@@ -392,4 +392,21 @@ public class XMLParserTest {
         //test
         Assert.assertEquals(expectedDrillInfo, drillInfo);
     }
+
+    @Test
+    public void testSongNameChange() throws ParserConfigurationException, SAXException, IOException, DrillXMLException {
+        //set the file url
+        File testFile = new File(path + "12-song-name-change.pnd");
+
+        //create the xml parser
+        XMLParser parser = new XMLParser();
+
+        //parse the file
+        DrillInfo drillInfo = parser.load(testFile);
+
+        //test
+        DrillInfo expectedDrillInfo = new DrillInfo();
+        expectedDrillInfo.setSongName("song");
+        Assert.assertEquals(expectedDrillInfo, drillInfo);
+    }
 }

--- a/src/test/resources/XMLParser/12-song-name-change.pnd
+++ b/src/test/resources/XMLParser/12-song-name-change.pnd
@@ -1,0 +1,5 @@
+<drill>
+    <song-name>
+        song
+    </song-name>
+</drill>


### PR DESCRIPTION
Closes #20

Updates the convertToXML method in DrillInfo to also write the song name to the file. Additional steps to implement this include:

 - add the constant 'SONG_NAME' to XMLConstants to reference the song name element
 - update the load method in XMLParser to read and set the song name

@vdye 