### PR TITLE
Improve the PDF drill rendering

### DIFF
--- a/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
+++ b/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
@@ -120,9 +120,6 @@ public class PDFGenerator {
         float imageHeight = drillHeight;
         Dimension dim = new Dimension((int) imageWidth, (int) imageHeight);
 
-        // Conversion factor
-        float ftToPx = imageWidth / field.TotalLength;
-
         // Initialize iterated variables
         int pageNumber = 1; // page number
         int moveNumber = 0; // move number
@@ -188,7 +185,7 @@ public class PDFGenerator {
             yPosition -= lineSpacing * fontSize;
 
             // add image to PDF
-            PdfImage image = new PdfImage(ftToPx * 3.0f, dim, move.getEndPositions());
+            PdfImage image = new PdfImage(field, move.getEndPositions());
             image.setPreferredSize(dim);
             image.setSize(dim);
             BufferedImage bi = createImage(image);

--- a/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
+++ b/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
@@ -104,7 +104,7 @@ public class PDFGenerator {
         float pageMarginY = 0.5f * 72f; // 1/2" margin Y (72 units/inch)
 
         float drillWidth = pageWidth - 2 * pageMarginX;
-        float drillHeight = drillWidth / (field.TotalLength / field.Height);
+        float drillHeight = drillWidth / (field.TotalLength / field.TotalHeight);
         float textMarginX = pageMarginX + (field.EndzoneWidth / field.TotalLength) * drillWidth;
 
         // Fonts

--- a/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
+++ b/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
@@ -115,9 +115,10 @@ public class PDFGenerator {
         float lineSpacing = 1.5f;
 
         // Drill image dimensions
-        // Units are in pixels
-        float imageWidth = drillWidth;
-        float imageHeight = drillHeight;
+        // Units are in pixels, scaled from 72dpi (the units of drillWidth and
+        // drillHeight) to 300dpi.
+        float imageWidth = drillWidth * (300f / 72f);
+        float imageHeight = drillHeight * (300f / 72f);
         Dimension dim = new Dimension((int) imageWidth, (int) imageHeight);
 
         // Initialize iterated variables

--- a/src/main/java/org/bigredbands/mb/models/CommandPair.java
+++ b/src/main/java/org/bigredbands/mb/models/CommandPair.java
@@ -260,9 +260,9 @@ public class CommandPair {
 
             //RankPosition format: lineType;front.x,front.y;mid.x,mid.y;end.x,end.y
             String str = this.destination.getLineType() + ";" +
-                    this.destination.getFront().getX() + "," + this.destination.getFront().getY() + ";" +
-                    this.destination.getMidpoint().getX() + "," + this.destination.getMidpoint().getY() + ";" +
-                    this.destination.getEnd().getX() + "," + this.destination.getEnd().getY();
+                    this.destination.getFront().X() + "," + this.destination.getFront().Y() + ";" +
+                    this.destination.getMidpoint().X() + "," + this.destination.getMidpoint().Y() + ";" +
+                    this.destination.getEnd().X() + "," + this.destination.getEnd().Y();
             Text destText = document.createTextNode(str);
             destTag.appendChild(destText);
         }

--- a/src/main/java/org/bigredbands/mb/models/Point.java
+++ b/src/main/java/org/bigredbands/mb/models/Point.java
@@ -1,25 +1,27 @@
 package org.bigredbands.mb.models;
 
+import java.awt.geom.Point2D;
+
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 import org.w3c.dom.Text;
 
-public class Point {
-
-    private Float x;
-    private Float y;
-
+/**
+ * The Point class represents a point or vector in two dimensional space,
+ * similar to the javafx.geometry.Point2D class. The X and Y coordinates of each
+ * point are stored and accessed as single-precision floating point values.
+ */
+public class Point extends Point2D.Float {
     public Point(float x, float y){
-        this.x = x;
-        this.y = y;
+        super(x, y);
     }
 
-    public float getX(){
-        return x;
+    public float X() {
+        return this.x;
     }
 
-    public float getY(){
-        return y;
+    public float Y() {
+        return this.y;
     }
 
     public Point interpolate(Point b, float t) {
@@ -36,29 +38,6 @@ public class Point {
         return "Point [x=" + x + ", y=" + y + "]";
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        //general comparisons
-        if (this == obj) {
-            return true;
-        }
-        if (obj == null) {
-            return false;
-        }
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-
-        //field comparisons
-        Point other = (Point) obj;
-        if (Math.abs(x - other.x) > 0.1) {
-            return false;
-        }
-        if (Math.abs(y - other.y) > 0.1) {
-            return false;
-        }
-        return true;
-    }
     public double distance(double x, double y){
         return Math.sqrt((this.x-x)*(this.x-x)+(this.y-y)*(this.y-y));
     }
@@ -72,7 +51,7 @@ public class Point {
         pointTag.appendChild(xTag);
 
         //add the coordinate value to the x coordinate tag
-        Text xText = document.createTextNode(x.toString());
+        Text xText = document.createTextNode(java.lang.Float.toString(x));
         xTag.appendChild(xText);
 
         //add the y coordinate tag
@@ -80,7 +59,7 @@ public class Point {
         pointTag.appendChild(yTag);
 
         //add the coordinate value to the y coordinate tag
-        Text yText = document.createTextNode(y.toString());
+        Text yText = document.createTextNode(java.lang.Float.toString(y));
         yTag.appendChild(yText);
 
         return pointTag;

--- a/src/main/java/org/bigredbands/mb/models/Point.java
+++ b/src/main/java/org/bigredbands/mb/models/Point.java
@@ -24,8 +24,81 @@ public class Point extends Point2D.Float {
         return this.y;
     }
 
+    /**
+     * Interpolate between this instance and a given point using a scalar value
+     * `t`.
+     *
+     * @param b The point to interpolate with this.
+     * @param t The relative weight of each point, where this point is weighted
+     *          with a factor `t` and `b` is weighted with `(1 - t)`.
+     * @return The interpolated Point.
+     */
     public Point interpolate(Point b, float t) {
         return new Point(this.x*(1-t) + b.x*t, this.y*(1-t) + b.y*t);
+    }
+
+    /**
+     * Normalizes the relative magnitude vector represented by this instance.
+     *
+     * @return A point representing the unit vector of this point.
+     */
+    public Point normalize() {
+        return this.multiply(1.0f / (float) this.distance(0, 0));
+    }
+
+    /**
+     * Get the vector orthogonal to this vector, equivalent to rotating the
+     * point about origin counter-clockwise.
+     *
+     * @return The vector orthogonal and equal in magnitude to this.
+     */
+    public Point orthogonal() {
+        return new Point(-this.y, this.x);
+    }
+
+    /**
+     * Returns a point with the coordinates of this point multiplied by the
+     * specified scalar factor.
+     *
+     * @param value The scalar multiplier.
+     * @return The product of this point and the scalar `value`.
+     */
+    public Point multiply(float value) {
+        return new Point(this.x * value, this.y * value);
+    }
+
+    /**
+     * Returns a point with the coordinates of the specified point added to the
+     * coordinates of this point.
+     *
+     * @param other The point to add to this point
+     * @return The sum of this and `other`
+     */
+    public Point add(Point other) {
+        return new Point(this.x + (float) other.getX(), this.y + (float) other.getY());
+    }
+
+    /**
+     * Returns a point with the coordinates of the specified point subtracted
+     * from the coordinates of this point.
+     *
+     * @param other The point to subtract from this point
+     * @return The difference between this and `other`.
+     */
+    public Point subtract(Point other) {
+        return this.add(other.multiply(-1.0f));
+    }
+
+    /**
+     * Computes the distance between this point and point `(x, y)`.
+     *
+     * @param x The X coordinate of the other point.
+     * @param y The Y coordinate of the other point.
+     * @return The distance between this and the point at the given coordinate.
+     */
+    public double distance(double x, double y) {
+        return Math.sqrt((this.x - x) * (this.x - x) +
+                         (this.y - y) * (this.y - y));
     }
 
     public void setPoint(float x, float y){
@@ -36,10 +109,6 @@ public class Point extends Point2D.Float {
     @Override
     public String toString() {
         return "Point [x=" + x + ", y=" + y + "]";
-    }
-
-    public double distance(double x, double y){
-        return Math.sqrt((this.x-x)*(this.x-x)+(this.y-y)*(this.y-y));
     }
 
     public Element convertToXML(Document document, String pointName) {

--- a/src/main/java/org/bigredbands/mb/models/RankPosition.java
+++ b/src/main/java/org/bigredbands/mb/models/RankPosition.java
@@ -25,8 +25,8 @@ public class RankPosition {
     public RankPosition(Point front, Point end){
         this.front = front;
         this.end = end;
-        float midX = (front.getX()+ end.getX())/2.0f;
-        float midY = (front.getY()+ end.getY())/2.0f;
+        float midX = (front.X()+ end.X())/2.0f;
+        float midY = (front.Y()+ end.Y())/2.0f;
         this.midpoint = new Point(midX, midY);
         this.lineType = LINE;
     }
@@ -39,10 +39,10 @@ public class RankPosition {
     }
 
     public RankPosition(RankPosition existingPosition) {
-        this.front = new Point(new Float(existingPosition.getFront().getX()), new Float(existingPosition.getFront().getY()));
-        this.end = new Point(new Float(existingPosition.getEnd().getX()), new Float(existingPosition.getEnd().getY()));
-        this.midpoint = new Point(new Float(existingPosition.getMidpoint().getX()), new Float(existingPosition.getMidpoint().getY()));
-        this.lineType = new Integer(existingPosition.getLineType());
+        this.front = new Point(existingPosition.getFront().X(), existingPosition.getFront().Y());
+        this.end = new Point(existingPosition.getEnd().X(), existingPosition.getEnd().Y());
+        this.midpoint = new Point(existingPosition.getMidpoint().X(), existingPosition.getMidpoint().Y());
+        this.lineType = existingPosition.getLineType();
     }
 
     /**
@@ -74,15 +74,15 @@ public class RankPosition {
     }
 
     public void incrementPointsYValue(float stepValue) {
-        front.setPoint(front.getX(), front.getY() + stepValue);
-        midpoint.setPoint(midpoint.getX(), midpoint.getY() + stepValue);
-        end.setPoint(end.getX(), end.getY() + stepValue);
+        front.setPoint(front.X(), front.Y() + stepValue);
+        midpoint.setPoint(midpoint.X(), midpoint.Y() + stepValue);
+        end.setPoint(end.X(), end.Y() + stepValue);
     }
 
     public void incrementPointsXValue(float stepValue) {
-        front.setPoint(front.getX() + stepValue, front.getY());
-        midpoint.setPoint(midpoint.getX() + stepValue, midpoint.getY());
-        end.setPoint(end.getX() + stepValue, end.getY());
+        front.setPoint(front.X() + stepValue, front.Y());
+        midpoint.setPoint(midpoint.X() + stepValue, midpoint.Y());
+        end.setPoint(end.X() + stepValue, end.Y());
     }
 
     @Override
@@ -173,8 +173,8 @@ public class RankPosition {
      */
     public Point rotate(float theta, Point origin, Point mover) {
         // determine length
-        float deltaX = (mover.getX()-origin.getX());
-        float deltaY = (origin.getY()-mover.getY());
+        float deltaX = (mover.X()-origin.X());
+        float deltaY = (origin.Y()-mover.Y());
         float length = (float) Math.sqrt(Math.pow(deltaX, 2) + Math.pow(deltaY, 2));
 
         //determine reference angle
@@ -198,19 +198,19 @@ public class RankPosition {
         float newX = (float) (length*Math.cos(theta + referenceAngle));
         float newY = (float) (length*Math.sin(theta + referenceAngle));
 
-        return new Point(origin.getX() + newX, origin.getY() - newY);
+        return new Point(origin.X() + newX, origin.Y() - newY);
     }
 
     public void pinwheelMove(float theta) {
         //determine length
         if(this.lineType==this.LINE) {
-            float midX = (front.getX()+ end.getX())/2.0f;
-            float midY = (front.getY()+ end.getY())/2.0f;
+            float midX = (front.X()+ end.X())/2.0f;
+            float midY = (front.Y()+ end.Y())/2.0f;
             this.midpoint = new Point(midX, midY);
         }
 
-        float deltaX = (front.getX()-end.getX());
-        float deltaY = (front.getY()-end.getY());
+        float deltaX = (front.X()-end.X());
+        float deltaY = (front.Y()-end.Y());
         float halfLength = (float) ((Math.sqrt( Math.pow(deltaX, 2) + Math.pow(deltaY, 2)))/2.0);
 
         float referenceAngle;
@@ -238,11 +238,11 @@ public class RankPosition {
         float newY = (float) (halfLength*Math.sin(theta + referenceAngle));
 
 
-        front.setPoint((midpoint.getX() + newX), (midpoint.getY()+ newY));
-        end.setPoint((midpoint.getX() - newX), (midpoint.getY()- newY));
+        front.setPoint((midpoint.X() + newX), (midpoint.Y()+ newY));
+        end.setPoint((midpoint.X() - newX), (midpoint.Y()- newY));
 
-        //float midX = (front.getX()+ end.getX())/2.0f;
-        //float midY = (front.getY()+ end.getY())/2.0f;
+        //float midX = (front.X()+ end.X())/2.0f;
+        //float midY = (front.Y()+ end.Y())/2.0f;
         //this.midpoint = new Point(midX, midY);
     }
 
@@ -254,15 +254,15 @@ public class RankPosition {
      */
     public void expansionMove(float headExpansion, float tailExpansion) {
         if(this.lineType==this.LINE) {
-            float midX = (front.getX()+ end.getX())/2.0f;
-            float midY = (front.getY()+ end.getY())/2.0f;
+            float midX = (front.X()+ end.X())/2.0f;
+            float midY = (front.Y()+ end.Y())/2.0f;
             this.midpoint = new Point(midX, midY);
         }
 
-        float frontX = front.getX();
-        float frontY = front.getY();
-        float endX = end.getX();
-        float endY = end.getY();
+        float frontX = front.X();
+        float frontY = front.Y();
+        float endX = end.X();
+        float endY = end.Y();
 
         float referenceAngle = (float) Math.atan(((frontY-endY)/(frontX-endX)));
 
@@ -286,34 +286,34 @@ public class RankPosition {
             end.setPoint(endX + deltaXEnd, endY + deltaYEnd);
         }
 
-        float midX = (front.getX()+ end.getX())/2.0f;
-        float midY = (front.getY()+ end.getY())/2.0f;
+        float midX = (front.X()+ end.X())/2.0f;
+        float midY = (front.Y()+ end.Y())/2.0f;
         this.midpoint = new Point(midX, midY);
 
     }
 
     public void curveMoveAuto(float dist, int type) {
         if(this.lineType==this.LINE) {
-            float midX = (front.getX()+ end.getX())/2.0f;
-            float midY = (front.getY()+ end.getY())/2.0f;
+            float midX = (front.X()+ end.X())/2.0f;
+            float midY = (front.Y()+ end.Y())/2.0f;
             this.midpoint = new Point(midX, midY);
         }
 
         // type = 0 for left, 1 for right
-        float vX = front.getX() - end.getX();
-        float vY = front.getY() - end.getY();
+        float vX = front.X() - end.X();
+        float vY = front.Y() - end.Y();
         float len = (float)Math.sqrt(vX*vX + vY*vY);
         if(lineType==LINE) {
-            midpoint = new Point(end.getX()+vX/2.0f,end.getY()+vY/2.0f);
+            midpoint = new Point(end.X()+vX/2.0f,end.Y()+vY/2.0f);
         }
         if(type==0) {
-            midpoint = new Point(midpoint.getX()+vY*dist/len, midpoint.getY()-vX*dist/len);
+            midpoint = new Point(midpoint.X()+vY*dist/len, midpoint.Y()-vX*dist/len);
         }
         else {
-            midpoint = new Point(midpoint.getX()-vY*dist/len, midpoint.getY()+vX*dist/len);
+            midpoint = new Point(midpoint.X()-vY*dist/len, midpoint.Y()+vX*dist/len);
         }
-        float vmX = front.getX() - midpoint.getX();
-        float vmY = front.getY() - midpoint.getY();
+        float vmX = front.X() - midpoint.X();
+        float vmY = front.Y() - midpoint.Y();
         // TODO: make this math a little better suited to checking for linearity
         if(vX*vmY == vmX*vY) {
             lineType = LINE;
@@ -329,9 +329,9 @@ public class RankPosition {
             return;
         }
         else {
-            float xDisp = (front.getX() + end.getX())/2.0f - midpoint.getX();
-            float yDisp = (front.getY() + end.getY())/2.0f - midpoint.getY();
-            midpoint.setPoint(midpoint.getX() + t*xDisp, midpoint.getY() + t*yDisp);
+            float xDisp = (front.X() + end.X())/2.0f - midpoint.X();
+            float yDisp = (front.Y() + end.Y())/2.0f - midpoint.Y();
+            midpoint.setPoint(midpoint.X() + t*xDisp, midpoint.Y() + t*yDisp);
         }
     }
 
@@ -342,10 +342,10 @@ public class RankPosition {
             return;
         }
         else {
-            float xDisp = midpoint.getX() - (front.getX() + end.getX())/2.0f;
-            float yDisp = midpoint.getY() - (front.getY() + end.getY())/2.0f;
-            front.setPoint(front.getX() + t*xDisp, front.getY() + t*yDisp);
-            end.setPoint(end.getX() + t*xDisp, end.getY() + t*yDisp);
+            float xDisp = midpoint.X() - (front.X() + end.X())/2.0f;
+            float yDisp = midpoint.Y() - (front.Y() + end.Y())/2.0f;
+            front.setPoint(front.X() + t*xDisp, front.Y() + t*yDisp);
+            end.setPoint(end.X() + t*xDisp, end.Y() + t*yDisp);
             if(t==1) {
                 lineType = LINE;
             }
@@ -353,10 +353,10 @@ public class RankPosition {
     }
 
     public void directMove(RankPosition endpoint, float t) {
-        float vX = front.getX() - end.getX();
-        float vY = front.getY() - end.getY();
+        float vX = front.X() - end.X();
+        float vY = front.Y() - end.Y();
         if(lineType==LINE) {
-            midpoint = new Point(end.getX()+vX/2.0f,end.getY()+vY/2.0f);
+            midpoint = new Point(end.X()+vX/2.0f,end.Y()+vY/2.0f);
         }
 
         if(this.lineType == CURVE || endpoint.lineType == CURVE) {
@@ -387,8 +387,8 @@ public class RankPosition {
             this.midpoint = this.front.interpolate(this.end, 0.5f);
         }
 
-        return (float)(this.front.distance(this.midpoint.getX(), this.midpoint.getY()) +
-                this.end.distance(this.midpoint.getX(), this.midpoint.getY()));
+        return (float)(this.front.distance(this.midpoint.X(), this.midpoint.Y()) +
+                this.end.distance(this.midpoint.X(), this.midpoint.Y()));
     }
 
     private static float getPathLength(ArrayList<Point>path) {
@@ -411,40 +411,40 @@ public class RankPosition {
     }
 
     public void cornerMove(float t, int xDir, int yDir, int leadDir) {
-        float length = (float)Math.sqrt(Math.pow(front.getX() - end.getX(),2)
-                + Math.pow(front.getY() - end.getY(),2));
+        float length = (float)Math.sqrt(Math.pow(front.X() - end.X(),2)
+                + Math.pow(front.Y() - end.Y(),2));
 
         // leadDir is 0 if initially oriented horizontally (1 if vertical)
-        if(leadDir == 0 && front.getX() != end.getX()) {
+        if(leadDir == 0 && front.X() != end.X()) {
             // front will be moving in the y-direction, end in x
-            if(xDir*front.getX() > xDir*end.getX()) {
+            if(xDir*front.X() > xDir*end.X()) {
                 // set the pivot point
-                midpoint = new Point(front.getX(),front.getY());
-                front.setPoint(front.getX(), front.getY()+t*length*yDir);
-                end.setPoint(end.getX()+t*length*xDir, end.getY());
+                midpoint = new Point(front.X(),front.Y());
+                front.setPoint(front.X(), front.Y()+t*length*yDir);
+                end.setPoint(end.X()+t*length*xDir, end.Y());
             }
             // end will be moving in the y-direction, front in x
             else {
                 // set the pivot point
-                midpoint = new Point(end.getX(),end.getY());
-                end.setPoint(end.getX(), end.getY()+t*length*yDir);
-                front.setPoint(front.getX()+t*length*xDir, front.getY());
+                midpoint = new Point(end.X(),end.Y());
+                end.setPoint(end.X(), end.Y()+t*length*yDir);
+                front.setPoint(front.X()+t*length*xDir, front.Y());
             }
         }
-        else if(leadDir == 1 && front.getY() != end.getY()) {
+        else if(leadDir == 1 && front.Y() != end.Y()) {
             // front moving in x, end in y
-            if(yDir*front.getY() > yDir*end.getY()) {
+            if(yDir*front.Y() > yDir*end.Y()) {
                 // set the pivot point
-                midpoint = new Point(front.getX(),front.getY());
-                front.setPoint(front.getX()+t*length*xDir, front.getY());
-                end.setPoint(end.getX(), end.getY()+t*length*yDir);
+                midpoint = new Point(front.X(),front.Y());
+                front.setPoint(front.X()+t*length*xDir, front.Y());
+                end.setPoint(end.X(), end.Y()+t*length*yDir);
             }
             // front moving in y, end in x
             else {
                 // set the pivot point
-                midpoint = new Point(end.getX(),end.getY());
-                front.setPoint(front.getX(), front.getY()+t*length*yDir);
-                end.setPoint(end.getX()+t*length*xDir, end.getY());
+                midpoint = new Point(end.X(),end.Y());
+                front.setPoint(front.X(), front.Y()+t*length*yDir);
+                end.setPoint(end.X()+t*length*xDir, end.Y());
             }
         }
         else {

--- a/src/main/java/org/bigredbands/mb/models/RankPosition.java
+++ b/src/main/java/org/bigredbands/mb/models/RankPosition.java
@@ -60,10 +60,18 @@ public class RankPosition {
     }
 
     /**
-     * Returns The midpoint/control point
+     * Returns The midpoint position
      */
     public Point getMidpoint() {
         return midpoint;
+    }
+
+    /**
+     * Returns The control point for this rank (assuming it is a curve)
+     */
+    public Point getCurveControlPoint() {
+        Point linearCenter = front.interpolate(end, 0.5f);
+        return linearCenter.add(midpoint.subtract(linearCenter).multiply(2.0f));
     }
 
     public int getLineType() {

--- a/src/main/java/org/bigredbands/mb/views/FieldStyle.java
+++ b/src/main/java/org/bigredbands/mb/views/FieldStyle.java
@@ -1,0 +1,92 @@
+package org.bigredbands.mb.views;
+
+import java.awt.Color;
+
+public class FieldStyle {
+    // ****************************
+    // ***** Field properties *****
+    // ****************************
+    private float fieldNumberSize;
+    public float getFieldNumberSize() { return fieldNumberSize; }
+    public FieldStyle setFieldNumberSize(float value) { fieldNumberSize = value; return this; }
+
+    private float hashWidth;
+    public float getHashWidth() { return hashWidth; }
+    public FieldStyle setHashWidth(float value) { hashWidth = value; return this; }
+
+    private float hashPeriod;
+    public float getHashPeriod() { return hashPeriod; }
+    public FieldStyle setHashPeriod(float value) { hashPeriod = value; return this; }
+
+    private float majorIncrementWidth;
+    public float getMajorIncrementWidth() { return majorIncrementWidth; }
+    public FieldStyle setMajorIncrementWidth(float value) { majorIncrementWidth = value; return this; }
+
+    private float minorIncrementWidth;
+    public float getMinorIncrementWidth() { return minorIncrementWidth; }
+    public FieldStyle setMinorIncrementWidth(float value) { minorIncrementWidth = value; return this; }
+
+    private float gridWidth;
+    public float getGridWidth() { return gridWidth; }
+    public FieldStyle setGridWidth(float value) { gridWidth = value; return this; }
+
+    private Color backgroundColor;
+    public Color getBackgroundColor() { return backgroundColor; }
+    public FieldStyle setBackgroundColor(Color value) { backgroundColor = value; return this; }
+
+    private Color fieldColor;
+    public Color getFieldColor() { return fieldColor; }
+    public FieldStyle setFieldColor(Color value) { fieldColor = value; return this; }
+
+    // ***************************
+    // ***** Rank properties *****
+    // ***************************
+    private float arrowWidth;
+    public float getArrowWidth() { return arrowWidth; }
+    public FieldStyle setArrowWidth(float value) { arrowWidth = value; return this; }
+
+    private float rankEndDiameter;
+    public float getRankEndDiameter() { return rankEndDiameter; }
+    public FieldStyle setRankEndDiameter(float value) { rankEndDiameter = value; return this; }
+
+    private float rankLabelSize;
+    public float getRankLabelSize() { return rankLabelSize; }
+    public FieldStyle setRankLabelSize(float value) { rankLabelSize = value; return this; }
+
+    private float rankStrokeWidth;
+    public float getRankStrokeWidth() { return rankStrokeWidth; }
+    public FieldStyle setRankStrokeWidth(float value) { rankStrokeWidth = value; return this; }
+
+    private Color rankColor;
+    public Color getRankColor() { return rankColor; }
+    public FieldStyle setRankColor(Color value) { rankColor = value; return this; }
+
+    private Color rankLabelColor;
+    public Color getRankLabelColor() { return rankLabelColor; }
+    public FieldStyle setRankLabelColor(Color value) { rankLabelColor = value; return this; }
+
+    private Color rankLabelBackground;
+    public Color getRankLabelBackground() { return rankLabelBackground; }
+    public FieldStyle setRankLabelBackground(Color value) { rankLabelBackground = value; return this; }
+
+    // All measurements are in *feet* to allow for uniform UI scaling
+    public FieldStyle() {
+        // Setup defaults
+        this.fieldNumberSize = 8.0f;
+        this.hashWidth = 1.0f;
+        this.hashPeriod = 5.2f;
+        this.majorIncrementWidth = 1.0f;
+        this.minorIncrementWidth = 0.5f;
+        this.gridWidth = 0.3f;
+        this.backgroundColor = Color.WHITE;
+        this.fieldColor = Color.WHITE;
+
+        this.arrowWidth = 7.0f;
+        this.rankEndDiameter = 5.0f;
+        this.rankLabelSize = 10.0f;
+        this.rankStrokeWidth = 2.5f;
+        this.rankColor = Color.BLUE;
+        this.rankLabelColor = Color.RED;
+        this.rankLabelBackground = new Color(0, 0, 0, 0); // Transparent by default
+    }
+}

--- a/src/main/java/org/bigredbands/mb/views/FieldView.java
+++ b/src/main/java/org/bigredbands/mb/views/FieldView.java
@@ -7,6 +7,7 @@ import java.awt.Font;
 import java.awt.FontMetrics;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.Shape;
 import java.awt.font.GlyphVector;
 import java.awt.geom.AffineTransform;
@@ -62,10 +63,16 @@ public abstract class FieldView extends JPanel {
 
         Graphics2D g2d = (Graphics2D)g;
         AffineTransform original = g2d.getTransform();
+        RenderingHints originalHints = g2d.getRenderingHints();
 
         // Convert to new coordinate system
         float scaleFactor = getScaleFactor(getSize());
         g2d.scale(scaleFactor, scaleFactor);
+
+        // Set rendering quality settings
+        g2d.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
+        g2d.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+        g2d.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
 
         drawField(g2d);
         drawFieldLines(g2d);
@@ -73,6 +80,7 @@ public abstract class FieldView extends JPanel {
         drawRanks(g2d);
 
         g2d.setTransform(original);
+        g2d.setRenderingHints(originalHints);
     }
 
     private float getScaleFactor(Dimension container) {

--- a/src/main/java/org/bigredbands/mb/views/FieldView.java
+++ b/src/main/java/org/bigredbands/mb/views/FieldView.java
@@ -1,0 +1,325 @@
+package org.bigredbands.mb.views;
+
+import java.awt.BasicStroke;
+import java.awt.Color;
+import java.awt.Dimension;
+import java.awt.Font;
+import java.awt.FontMetrics;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.Shape;
+import java.awt.font.GlyphVector;
+import java.awt.geom.AffineTransform;
+import java.awt.geom.Arc2D;
+import java.awt.geom.Line2D;
+import java.awt.geom.Path2D;
+import java.awt.geom.QuadCurve2D;
+import java.awt.geom.Rectangle2D;
+import java.util.HashMap;
+
+import javax.swing.JPanel;
+
+import org.bigredbands.mb.models.Field;
+import org.bigredbands.mb.models.Point;
+import org.bigredbands.mb.models.RankPosition;
+
+/**
+ * This class represents the generic "field view" used in rendering the editor,
+ * move thumbnails, and exported PDF.
+ */
+public abstract class FieldView extends JPanel {
+
+    protected final Field field;
+    private FieldStyle fieldStyle;
+
+    protected FieldView(Field field, FieldStyle style) {
+        // Set the field information
+        this.field = field;
+        this.fieldStyle = style;
+    }
+
+    protected FieldView(Field field) {
+        this(field, new FieldStyle());
+    }
+
+    public abstract HashMap<String, RankPosition> getRankPositions();
+
+    public void setFieldStyle(FieldStyle fieldStyle) {
+        this.fieldStyle = fieldStyle;
+    }
+
+    // Override getPreferredSize to preserve fixed aspect ratio for the image
+    @Override
+    public Dimension getPreferredSize() {
+        float scaleFactor = getScaleFactor(super.getPreferredSize());
+        return new Dimension((int)(scaleFactor * field.TotalLength),
+                             (int)(scaleFactor * field.TotalHeight));
+    }
+
+    @Override
+    public void paintComponent(Graphics g) {
+        super.paintComponent(g);
+
+        Graphics2D g2d = (Graphics2D)g;
+        AffineTransform original = g2d.getTransform();
+
+        // Convert to new coordinate system
+        float scaleFactor = getScaleFactor(getSize());
+        g2d.scale(scaleFactor, scaleFactor);
+
+        drawField(g2d);
+        drawFieldLines(g2d);
+        drawHashes(g2d);
+        drawRanks(g2d);
+
+        g2d.setTransform(original);
+    }
+
+    private float getScaleFactor(Dimension container) {
+        float scaleFactor;
+        float containerAspectRatio = (float) (container.getWidth() / container.getHeight());
+
+        if (containerAspectRatio > field.AspectRatio) {
+            // Container is wider than image - scale to height
+            scaleFactor = (float) container.getHeight() / field.TotalHeight;
+        } else {
+            // Container is taller than image - scale to width
+            scaleFactor = (float) container.getWidth() / field.TotalLength;
+        }
+
+        return scaleFactor;
+    }
+
+    private void drawField(Graphics2D g) {
+        // Paint the canvas background
+        g.setColor(fieldStyle.getBackgroundColor());
+        g.fill(g.getClipBounds());
+
+        Rectangle2D fieldRect = new Rectangle2D.Float(field.EndzoneWidth, field.SidelineWidth,
+            field.Length, field.Height);
+        g.setColor(fieldStyle.getFieldColor());
+        g.fill(fieldRect);
+
+        g.setColor(Color.BLACK);
+        g.setStroke(new BasicStroke(fieldStyle.getMajorIncrementWidth(),
+            BasicStroke.CAP_BUTT,
+            BasicStroke.JOIN_MITER));
+        g.draw(fieldRect);
+    }
+
+    /**
+     * Draw the hashmarks on the football field
+     * @param g - the graphics used to draw
+     */
+    private void drawHashes(Graphics2D g) {
+        BasicStroke dashed = new BasicStroke(
+            fieldStyle.getHashWidth(),
+            BasicStroke.CAP_BUTT,
+            BasicStroke.JOIN_MITER,
+            10.0f,
+            new float[]{ fieldStyle.getHashPeriod() },
+            0.0f);
+
+        g.setStroke(dashed);
+        g.setColor(Color.BLACK);
+
+        for (float hash : field.Hashes) {
+            g.draw(new Line2D.Float(
+                field.EndzoneWidth,
+                (field.TotalHeight - field.SidelineWidth - hash),
+                (field.EndzoneWidth + field.Length),
+                (field.TotalHeight - field.SidelineWidth - hash)
+            ));
+        }
+    }
+
+    /**
+     * Helper function used to draw the numbers on the football field
+     * @param g - the graphics used to draw
+     */
+    private void drawNumbers(Graphics2D g) {
+        int increments = (int) (field.Length / field.Increment);
+
+        g.setColor(Color.BLACK);
+        g.setFont(new Font(Font.SANS_SERIF, 0, (int) fieldStyle.getFieldNumberSize()));
+        FontMetrics metrics = g.getFontMetrics();
+
+        int markedIncrements = increments / field.MajorIncrementFrequency;
+        for (int i = 1; i < markedIncrements; i++) {
+            String numberString;
+            if (i <= markedIncrements / 2) {
+                numberString = i + " 0"; // Prints "1 0" (for example)
+            } else {
+                numberString = (markedIncrements - i) + " 0";
+            }
+            int pxStringWidth = metrics.stringWidth(numberString);
+
+            // Draw numbers at top of page
+            g.drawString(numberString,
+                field.EndzoneWidth + i * field.MajorIncrementFrequency * field.Increment - pxStringWidth / 2,
+                field.SidelineWidth + 20.0f);
+
+            // Draw numbers at bottom of page
+            g.drawString(numberString,
+                field.EndzoneWidth + i * field.MajorIncrementFrequency * field.Increment - pxStringWidth / 2,
+                field.TotalHeight - field.SidelineWidth - 20.0f);
+        }
+    }
+
+    /**
+     * This is a helper function designed to draw lines on the field
+     */
+    private void drawFieldLines(Graphics2D g) {
+        g.setColor(Color.BLACK);
+
+        drawNumbers(g);
+
+        // Note: image origin (0,0) is in upper left
+
+        // Divide the field horizontally into increments & draw each one
+        int increments = (int) (field.Length / field.Increment);
+        for (int i = 0; i < increments + 1; i++) {
+            float strokeWidth = fieldStyle.getGridWidth();
+            if (i % field.MajorIncrementFrequency == 0) {
+                strokeWidth = fieldStyle.getMajorIncrementWidth();
+            } else if (i % field.MinorIncrementFrequency == 0) {
+                strokeWidth = fieldStyle.getMinorIncrementWidth();
+            }
+            if (strokeWidth == 0) {
+                continue;
+            }
+            g.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
+
+            g.draw(new Line2D.Float(
+                field.EndzoneWidth + field.Increment * i,
+                field.SidelineWidth,
+                field.EndzoneWidth + field.Increment * i,
+                field.SidelineWidth + field.Height
+            ));
+        }
+
+        increments = (int) (field.Height / field.Increment);
+        for (int i = 0; i < increments + 1; i++) {
+            float strokeWidth = fieldStyle.getGridWidth();
+
+            // Unlike horizontal increments, do not include major increment style
+            if (i % field.MinorIncrementFrequency == 0) {
+                strokeWidth = fieldStyle.getMinorIncrementWidth();
+            }
+            if (strokeWidth == 0) {
+                continue;
+            }
+            g.setStroke(new BasicStroke(strokeWidth, BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
+
+            g.draw(new Line2D.Float(
+                field.EndzoneWidth,
+                field.TotalHeight - field.SidelineWidth - field.Increment * i,
+                field.EndzoneWidth + field.Length,
+                field.TotalHeight - field.SidelineWidth - field.Increment * i
+            ));
+        }
+
+        // Reset stroke
+        g.setStroke(new BasicStroke());
+    }
+
+    private void drawArrowhead(Graphics2D g, Point startPx, Point direction) {
+        Path2D arrowhead = new Path2D.Float();
+        Point dirNorm = direction.normalize();
+        float arrowHeightPx = (float) Math.sin(Math.toRadians(60)) * fieldStyle.getArrowWidth();
+        float arrowBasePx = fieldStyle.getArrowWidth();
+
+        // The arrowhead point
+        Point vertex = startPx.add(dirNorm.multiply(arrowHeightPx / 2.0f));
+        arrowhead.moveTo(vertex.X(), vertex.Y());
+
+        // Base of the arrowhead
+        Point orthoNorm = dirNorm.orthogonal();
+        vertex = startPx.subtract(dirNorm.multiply(arrowHeightPx / 2.0f)
+            .add(orthoNorm.multiply(arrowBasePx / 2.0f)));
+            arrowhead.lineTo(vertex.X(), vertex.Y());
+
+        vertex = startPx.subtract(dirNorm.multiply(arrowHeightPx / 2.0f)
+            .subtract(orthoNorm.multiply(arrowBasePx / 2.0f)));
+        arrowhead.lineTo(vertex.X(), vertex.Y());
+
+        arrowhead.closePath();
+        g.fill(arrowhead);
+    }
+
+    private void drawRank(Graphics2D g, String rankName, RankPosition rank) {
+        Point fieldOffset = new Point(field.EndzoneWidth, field.SidelineWidth);
+
+        // Draw the rank arrow
+        // Draw the line
+        g.setStroke(new BasicStroke(fieldStyle.getRankStrokeWidth(),
+            BasicStroke.CAP_BUTT, BasicStroke.JOIN_MITER));
+        g.setColor(fieldStyle.getRankColor());
+
+        // TODO: convert rank scale to feet (avoid the multiply())
+        Point start = rank.getFront().multiply(3.0f).add(fieldOffset);
+        Point midpoint = rank.getMidpoint().multiply(3.0f).add(fieldOffset);
+        Point end = rank.getEnd().multiply(3.0f).add(fieldOffset);
+
+        Point arrowDir;
+        switch (rank.getLineType()) {
+            case RankPosition.LINE:
+                g.draw(new Line2D.Float(start, end));
+                arrowDir = start.subtract(end);
+                break;
+            case RankPosition.CURVE:
+                // TODO: convert rank scale to feet (avoid the multiply())
+                Point control = rank.getCurveControlPoint().multiply(3.0f).add(fieldOffset);
+                g.draw(new QuadCurve2D.Float(start.X(), start.Y(),
+                    control.X(), control.Y(),
+                    end.X(), end.Y()));
+                arrowDir = start.subtract(control);
+                break;
+            case RankPosition.CORNER:
+                Path2D.Float rankLine = new Path2D.Float();
+                rankLine.moveTo(start.X(), start.Y());
+                rankLine.lineTo(midpoint.X(), midpoint.Y());
+                rankLine.lineTo(end.X(), end.Y());
+                g.draw(rankLine);
+                arrowDir = start.subtract(midpoint);
+                break;
+            default:
+                System.out.println("TRIED CREATE SOMETHING THAT WASN'T A LINE, CURVE, OR CORNER");
+                return;
+        }
+
+        // Draw endpoints
+        g.fill(new Arc2D.Float((end.X() - 0.5f * fieldStyle.getRankEndDiameter()),
+            (end.Y() - 0.5f * fieldStyle.getRankEndDiameter()),
+            fieldStyle.getRankEndDiameter(),
+            fieldStyle.getRankEndDiameter(),
+            0.0f, 360.0f,
+            Arc2D.CHORD));
+        drawArrowhead(g, start, arrowDir);
+
+        // Draw the rank label
+        Font rankFont = new Font(Font.SANS_SERIF, Font.BOLD, (int) fieldStyle.getRankLabelSize());
+        GlyphVector rankLabel = rankFont.createGlyphVector(g.getFontRenderContext(), rankName);
+        Shape rankShape = rankLabel.getOutline(midpoint.X(), midpoint.Y());
+
+        g.setStroke(new BasicStroke(0.1f * fieldStyle.getRankLabelSize()));
+        g.setColor(fieldStyle.getRankLabelBackground());
+        g.draw(rankShape);
+        g.setColor(fieldStyle.getRankLabelColor());
+        g.fill(rankShape);
+    }
+
+    /**
+     * This function draws the ranks (line, curve, and corner) to the canvas.
+     */
+    private void drawRanks(Graphics2D g) {
+        HashMap<String, RankPosition> rankPositions = getRankPositions();
+        if (rankPositions == null) {
+            return;
+        }
+
+        for (String rankName : rankPositions.keySet()) {
+            drawRank(g, rankName, rankPositions.get(rankName));
+        }
+    }
+}

--- a/src/main/java/org/bigredbands/mb/views/FieldView.java
+++ b/src/main/java/org/bigredbands/mb/views/FieldView.java
@@ -248,6 +248,13 @@ public abstract class FieldView extends JPanel {
     }
 
     private void drawRank(Graphics2D g, String rankName, RankPosition rank) {
+        // TODO: somewhere in either the rank positioning or the grid snapping
+        // code, there is a 0.6ft error in the y-axis coordinate. If we wanted
+        // to correct for this, we'd add 0.6 to the fieldOffset y-axis value.
+        //
+        // In the future, we should add an option to fix affected .pnd files
+        // automatically so we do not need to adjust here. Since that's the
+        // ideal long-term solution, let's not add the offset here.
         Point fieldOffset = new Point(field.EndzoneWidth, field.SidelineWidth);
 
         // Draw the rank arrow

--- a/src/main/java/org/bigredbands/mb/views/FootballField.java
+++ b/src/main/java/org/bigredbands/mb/views/FootballField.java
@@ -458,7 +458,7 @@ public class FootballField extends JPanel {
      private void drawRankPoint(Point p){
          int size = 10;
          Graphics2D g2 = (Graphics2D) this.getGraphics();
-         g2.fillOval((int)p.getX()-(size/2),(int)p.getY()-(size/2),size,size);
+         g2.fillOval((int)p.X()-(size/2),(int)p.Y()-(size/2),size,size);
      }
 
      /**
@@ -469,7 +469,7 @@ public class FootballField extends JPanel {
          int size = 10;
          Graphics2D g2 = (Graphics2D) this.getGraphics();
          g2.setPaint(Color.GRAY);
-         g2.fillOval((int)p.getX()-(size/2),(int)p.getY()-(size/2),size,size);
+         g2.fillOval((int)p.X()-(size/2),(int)p.Y()-(size/2),size,size);
      }
 
 
@@ -496,10 +496,10 @@ public class FootballField extends JPanel {
             //define points for each line
             locus = rankHash.get(rankName);
 
-            x1 = locus.getFront().getX();
-            y1 = locus.getFront().getY();
-            x4 = locus.getEnd().getX();
-            y4 = locus.getEnd().getY();
+            x1 = locus.getFront().X();
+            y1 = locus.getFront().Y();
+            x4 = locus.getEnd().X();
+            y4 = locus.getEnd().Y();
 
             switch (locus.getLineType()) {
                 case RankPosition.LINE:
@@ -510,15 +510,15 @@ public class FootballField extends JPanel {
                             topLeftY + y4*scaleFactor));
                     break;
                 case RankPosition.CURVE:
-                    float xMid=locus.getMidpoint().getX();
-                    float yMid=locus.getMidpoint().getY();
+                    float xMid=locus.getMidpoint().X();
+                    float yMid=locus.getMidpoint().Y();
                     x2=(x1+x4)/2+2*(xMid-(x1+x4)/2);
                     y2=(y1+y4)/2+2*(yMid-(y1+y4)/2);
                     shapeMap.put(rankName, new QuadCurve2D.Float(topLeftX + x1*scaleFactor, topLeftY + y1*scaleFactor, topLeftX + x2*scaleFactor, topLeftY + y2*scaleFactor, topLeftX + x4*scaleFactor, topLeftY + y4*scaleFactor));
                     break;
                 case RankPosition.CORNER:
-                    xMid=locus.getMidpoint().getX();
-                    yMid=locus.getMidpoint().getY();
+                    xMid=locus.getMidpoint().X();
+                    yMid=locus.getMidpoint().Y();
                     Path2D cornerPath = new Path2D.Float();
 
                     cornerPath.moveTo(topLeftX + x1*scaleFactor,topLeftY + y1*scaleFactor);
@@ -545,10 +545,10 @@ public class FootballField extends JPanel {
 
         //define points for each line
 
-        x1 = locus.getFront().getX();
-        y1 = locus.getFront().getY();
-        x4 = locus.getEnd().getX();
-        y4 = locus.getEnd().getY();
+        x1 = locus.getFront().X();
+        y1 = locus.getFront().Y();
+        x4 = locus.getEnd().X();
+        y4 = locus.getEnd().Y();
 
         switch (locus.getLineType()) {
         case RankPosition.LINE:
@@ -558,8 +558,8 @@ public class FootballField extends JPanel {
                     topLeftX + x4*scaleFactor,
                     topLeftY + y4*scaleFactor);
         case RankPosition.CURVE:
-            float xMid=locus.getMidpoint().getX();
-            float yMid=locus.getMidpoint().getY();
+            float xMid=locus.getMidpoint().X();
+            float yMid=locus.getMidpoint().Y();
             x2=(x1+x4)/2+2*(xMid-(x1+x4)/2);
             y2=(y1+y4)/2+2*(yMid-(y1+y4)/2);
             return new QuadCurve2D.Float(topLeftX + x1*scaleFactor,
@@ -569,8 +569,8 @@ public class FootballField extends JPanel {
                     topLeftX + x4*scaleFactor,
                     topLeftY + y4*scaleFactor);
         case RankPosition.CORNER:
-            xMid=locus.getMidpoint().getX();
-            yMid=locus.getMidpoint().getY();
+            xMid=locus.getMidpoint().X();
+            yMid=locus.getMidpoint().Y();
             Path2D cornerPath = new Path2D.Float();
 
             cornerPath.moveTo(topLeftX + x1*scaleFactor,topLeftY + y1*scaleFactor);
@@ -721,13 +721,13 @@ public class FootballField extends JPanel {
                             System.out.println("right clicked on DTP destination!");
                             if(DTPShape instanceof Line2D){
                                 DTPRank.setLineType(RankPosition.CURVE);
-                                DTPRank.getMidpoint().setPoint((DTPRank.getEnd().getX()+DTPRank.getFront().getX())/2,
-                                        (DTPRank.getEnd().getY()+DTPRank.getFront().getY())/2);
+                                DTPRank.getMidpoint().setPoint((DTPRank.getEnd().X()+DTPRank.getFront().X())/2,
+                                        (DTPRank.getEnd().Y()+DTPRank.getFront().Y())/2);
                             }
                             if(DTPShape instanceof QuadCurve2D){
                                 DTPRank.setLineType(RankPosition.LINE);
-                                DTPRank.getMidpoint().setPoint((DTPRank.getEnd().getX()+DTPRank.getFront().getX())/2,
-                                        (DTPRank.getEnd().getY()+DTPRank.getFront().getY())/2);
+                                DTPRank.getMidpoint().setPoint((DTPRank.getEnd().X()+DTPRank.getFront().X())/2,
+                                        (DTPRank.getEnd().Y()+DTPRank.getFront().Y())/2);
                             }
 
                             projectView.repaintFieldPanel();
@@ -745,11 +745,11 @@ public class FootballField extends JPanel {
                                 if(lineMap.get(rankName) instanceof Line2D){
                                     RankPosition rightClickedRank=mainView.getRankPositions().get(rankName);
                                     rightClickedRank.setLineType(RankPosition.CURVE);
-                                    rightClickedRank.getMidpoint().setPoint((rightClickedRank.getEnd().getX()+rightClickedRank.getFront().getX())/2, (rightClickedRank.getEnd().getY()+rightClickedRank.getFront().getY())/2);
+                                    rightClickedRank.getMidpoint().setPoint((rightClickedRank.getEnd().X()+rightClickedRank.getFront().X())/2, (rightClickedRank.getEnd().Y()+rightClickedRank.getFront().Y())/2);
                                 } else if(lineMap.get(rankName) instanceof QuadCurve2D) {
                                     RankPosition rightClickedRank=mainView.getRankPositions().get(rankName);
                                     rightClickedRank.setLineType(RankPosition.LINE);
-                                    rightClickedRank.getMidpoint().setPoint((rightClickedRank.getEnd().getX()+rightClickedRank.getFront().getX())/2, (rightClickedRank.getEnd().getY()+rightClickedRank.getFront().getY())/2);
+                                    rightClickedRank.getMidpoint().setPoint((rightClickedRank.getEnd().X()+rightClickedRank.getFront().X())/2, (rightClickedRank.getEnd().Y()+rightClickedRank.getFront().Y())/2);
                                 }
 
                                 projectView.repaintFieldPanel();
@@ -980,8 +980,8 @@ public class FootballField extends JPanel {
                                 Point head = mainView.getRankPositions().get(rank).getFront();
 
                                 // TODO: HACK - snap to most recent head
-                                float preSnapX = head.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                                float preSnapY = head.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                                float preSnapX = head.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                                float preSnapY = head.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                                 float headSnapX = preSnapX;
                                 float headSnapY = preSnapY;
                                 if (mainView.isExactGrid()) {
@@ -990,8 +990,8 @@ public class FootballField extends JPanel {
                                     headSnapY = gridMatchY(preSnapY);
                                 }
 
-                                float endSnapX = end.getX()+(arg0.getX()-xDragOrigin)/(scaleFactor) + (headSnapX - preSnapX);
-                                float endSnapY = end.getY()+(arg0.getY()-yDragOrigin)/(scaleFactor) + (headSnapY - preSnapY);
+                                float endSnapX = end.X()+(arg0.getX()-xDragOrigin)/(scaleFactor) + (headSnapX - preSnapX);
+                                float endSnapY = end.Y()+(arg0.getY()-yDragOrigin)/(scaleFactor) + (headSnapY - preSnapY);
 
                                 head.setPoint(headSnapX, headSnapY);
                                 end.setPoint(endSnapX, endSnapY);
@@ -1004,8 +1004,8 @@ public class FootballField extends JPanel {
 
                             } else if (mainView.getSelectPoint() == HEAD_SELECTED) {
                                 Point head = mainView.getRankPositions().get(rank).getFront();
-                                float snapX = head.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                                float snapY = head.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                                float snapX = head.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                                float snapY = head.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                                 if (mainView.isExactGrid()) {
                                     // snap the new head position to the grid
                                     snapX = gridMatchX(snapX);
@@ -1021,8 +1021,8 @@ public class FootballField extends JPanel {
                                 projectView.repaintScrollBar();
                             } else {
                                 Point end=mainView.getRankPositions().get(rank).getEnd();
-                                float snapX = end.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                                float snapY = end.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                                float snapX = end.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                                float snapY = end.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                                 if (mainView.isExactGrid()) {
                                     // snap the new head position to the grid
                                     snapX = gridMatchX(snapX);
@@ -1043,8 +1043,8 @@ public class FootballField extends JPanel {
                                 Point mid = mainView.getRankPositions().get(rank).getMidpoint();
 
                                 // TODO: HACK - snap to most recent head
-                                float preSnapX = head.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                                float preSnapY = head.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                                float preSnapX = head.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                                float preSnapY = head.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                                 float headSnapX = preSnapX;
                                 float headSnapY = preSnapY;
                                 if (mainView.isExactGrid()) {
@@ -1053,10 +1053,10 @@ public class FootballField extends JPanel {
                                     headSnapY = gridMatchY(preSnapY);
                                 }
 
-                                float endSnapX = end.getX()+(arg0.getX()-xDragOrigin)/(scaleFactor) + (headSnapX - preSnapX);
-                                float endSnapY = end.getY()+(arg0.getY()-yDragOrigin)/(scaleFactor) + (headSnapY - preSnapY);
-                                float midSnapX = mid.getX()+(arg0.getX()-xDragOrigin)/(scaleFactor) + (headSnapX - preSnapX);
-                                float midSnapY = mid.getY()+(arg0.getY()-yDragOrigin)/(scaleFactor) + (headSnapY - preSnapY);
+                                float endSnapX = end.X()+(arg0.getX()-xDragOrigin)/(scaleFactor) + (headSnapX - preSnapX);
+                                float endSnapY = end.Y()+(arg0.getY()-yDragOrigin)/(scaleFactor) + (headSnapY - preSnapY);
+                                float midSnapX = mid.X()+(arg0.getX()-xDragOrigin)/(scaleFactor) + (headSnapX - preSnapX);
+                                float midSnapY = mid.Y()+(arg0.getY()-yDragOrigin)/(scaleFactor) + (headSnapY - preSnapY);
 
                                 head.setPoint(headSnapX, headSnapY);
                                 end.setPoint(endSnapX, endSnapY);
@@ -1071,8 +1071,8 @@ public class FootballField extends JPanel {
                                 projectView.repaintScrollBar();
                             } else if(mainView.getSelectPoint()==HEAD_SELECTED){
                                 Point head=mainView.getRankPositions().get(rank).getFront();
-                                float snapX = head.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                                float snapY = head.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                                float snapX = head.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                                float snapY = head.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                                 if (mainView.isExactGrid()) {
                                     // snap the new head position to the grid
                                     snapX = gridMatchX(snapX);
@@ -1087,8 +1087,8 @@ public class FootballField extends JPanel {
                                 projectView.repaintScrollBar();
                             } else if(mainView.getSelectPoint()==END_SELECTED){
                                 Point end=mainView.getRankPositions().get(rank).getEnd();
-                                float snapX = end.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                                float snapY = end.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                                float snapX = end.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                                float snapY = end.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                                 System.out.println((arg0.getX()-xDragOrigin)*scaleFactor);
                                 if (mainView.isExactGrid()) {
                                     // snap the new head position to the grid
@@ -1104,8 +1104,8 @@ public class FootballField extends JPanel {
                                 projectView.repaintScrollBar();
                             } else {
                                 Point mid=mainView.getRankPositions().get(rank).getMidpoint();
-                                float snapX = mid.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                                float snapY = mid.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                                float snapX = mid.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                                float snapY = mid.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                                 System.out.println((arg0.getX()-xDragOrigin)*scaleFactor);
                                 if (mainView.isExactGrid()) {
                                     // snap the new head position to the grid
@@ -1139,18 +1139,18 @@ public class FootballField extends JPanel {
                         if(mainView.getSelectPoint() == LINE_SELECTED) {
                             Point end = DTPRank.getEnd();
                             Point head = DTPRank.getFront();
-                            end.setPoint(end.getX()+(arg0.getX()-xDragOrigin)/(scaleFactor),
-                                    end.getY()+(arg0.getY()-yDragOrigin)/(scaleFactor));
-                            head.setPoint(head.getX()+(arg0.getX()-xDragOrigin)/(scaleFactor),
-                                    head.getY()+(arg0.getY()-yDragOrigin)/(scaleFactor));
+                            end.setPoint(end.X()+(arg0.getX()-xDragOrigin)/(scaleFactor),
+                                    end.Y()+(arg0.getY()-yDragOrigin)/(scaleFactor));
+                            head.setPoint(head.X()+(arg0.getX()-xDragOrigin)/(scaleFactor),
+                                    head.Y()+(arg0.getY()-yDragOrigin)/(scaleFactor));
                             xDragOrigin=arg0.getX();
                             yDragOrigin=arg0.getY();
                             repaint();
                             projectView.repaintScrollBar();
                         } else if(mainView.getSelectPoint() == HEAD_SELECTED) {
                             Point head = DTPRank.getFront();
-                            float newX = head.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                            float newY = head.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                            float newX = head.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                            float newY = head.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                             System.out.println((arg0.getX()-xDragOrigin)*scaleFactor);
                             if (mainView.isExactGrid()) {
                                 // snap the new head position to the grid
@@ -1164,8 +1164,8 @@ public class FootballField extends JPanel {
                             projectView.repaintScrollBar();
                         } else {
                             Point end = DTPRank.getEnd();
-                            float newX = end.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                            float newY = end.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                            float newX = end.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                            float newY = end.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                             System.out.println((arg0.getX()-xDragOrigin)*scaleFactor);
                             if (mainView.isExactGrid()) {
                                 // snap the new head position to the grid
@@ -1183,20 +1183,20 @@ public class FootballField extends JPanel {
                             Point end = DTPRank.getEnd();
                             Point head = DTPRank.getFront();
                             Point mid = DTPRank.getMidpoint();
-                            end.setPoint(end.getX()+(arg0.getX()-xDragOrigin)/(scaleFactor),
-                                    end.getY()+(arg0.getY()-yDragOrigin)/(scaleFactor));
-                            head.setPoint(head.getX()+(arg0.getX()-xDragOrigin)/(scaleFactor),
-                                    head.getY()+(arg0.getY()-yDragOrigin)/(scaleFactor));
-                            mid.setPoint(mid.getX()+(arg0.getX()-xDragOrigin)/(scaleFactor),
-                                    mid.getY()+(arg0.getY()-yDragOrigin)/(scaleFactor));
+                            end.setPoint(end.X()+(arg0.getX()-xDragOrigin)/(scaleFactor),
+                                    end.Y()+(arg0.getY()-yDragOrigin)/(scaleFactor));
+                            head.setPoint(head.X()+(arg0.getX()-xDragOrigin)/(scaleFactor),
+                                    head.Y()+(arg0.getY()-yDragOrigin)/(scaleFactor));
+                            mid.setPoint(mid.X()+(arg0.getX()-xDragOrigin)/(scaleFactor),
+                                    mid.Y()+(arg0.getY()-yDragOrigin)/(scaleFactor));
                             xDragOrigin=arg0.getX();
                             yDragOrigin=arg0.getY();
                             repaint();
                             projectView.repaintScrollBar();
                         } else if(mainView.getSelectPoint()==HEAD_SELECTED) {
                             Point head = DTPRank.getFront();
-                            float newX = head.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                            float newY = head.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                            float newX = head.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                            float newY = head.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                             System.out.println((arg0.getX()-xDragOrigin)*scaleFactor);
                             if (mainView.isExactGrid()) {
                                 // snap the new head position to the grid
@@ -1211,8 +1211,8 @@ public class FootballField extends JPanel {
                             projectView.repaintScrollBar();
                         } else if(mainView.getSelectPoint()==END_SELECTED){
                             Point end = DTPRank.getEnd();
-                            float newX = end.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                            float newY = end.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                            float newX = end.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                            float newY = end.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                             System.out.println((arg0.getX()-xDragOrigin)*scaleFactor);
                             if (mainView.isExactGrid()) {
                                 // snap the new head position to the grid
@@ -1226,8 +1226,8 @@ public class FootballField extends JPanel {
                             projectView.repaintScrollBar();
                         } else {
                             Point mid = DTPRank.getMidpoint();
-                            float newX = mid.getX() + (arg0.getX()-xDragOrigin)/scaleFactor;
-                            float newY = mid.getY() + (arg0.getY()-yDragOrigin)/scaleFactor;
+                            float newX = mid.X() + (arg0.getX()-xDragOrigin)/scaleFactor;
+                            float newY = mid.Y() + (arg0.getY()-yDragOrigin)/scaleFactor;
                             System.out.println((arg0.getX()-xDragOrigin)*scaleFactor);
                             if (mainView.isExactGrid()) {
                                 // snap the new head position to the grid

--- a/src/main/java/org/bigredbands/mb/views/PdfImage.java
+++ b/src/main/java/org/bigredbands/mb/views/PdfImage.java
@@ -1,60 +1,21 @@
 package org.bigredbands.mb.views;
 
-import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics;
-import java.awt.Graphics2D;
-import java.awt.Shape;
 import java.util.HashMap;
-import java.util.HashSet;
 
-import javax.swing.JPanel;
-
+import org.bigredbands.mb.models.Field;
 import org.bigredbands.mb.models.RankPosition;
 
-public class PdfImage extends JPanel {
+public class PdfImage extends FieldView {
 
-    private float scaleFactor;
-    private Dimension containingDimension;
-    private MainView mainView;
     private HashMap<String, RankPosition> rankPositions;
 
-    public PdfImage(float scaleFactor, Dimension containingDimension, HashMap<String, RankPosition> rankPositions) {
-        super();
-
-        this.scaleFactor = scaleFactor;
-        this.containingDimension = containingDimension;
+    public PdfImage(Field field, HashMap<String, RankPosition> rankPositions) {
+        super(field);
         this.rankPositions = rankPositions;
-
     }
 
-    @Override
-    public void paintComponent(Graphics g) {
-        super.paintComponent(g);
-
-        Graphics2D g2d = (Graphics2D)g;
-        g2d.setColor(Color.WHITE);
-        g2d.fill(g2d.getClipBounds());
-
-        g.setColor(Color.BLACK);
-        FootballField.drawFieldLines(g, containingDimension, 0, 0, 0);
-        FootballField.drawHashes(g, (int) (FootballField.END_ZONE_LENGTH * scaleFactor), 0, scaleFactor);
-
-        FootballField.drawRanks(
-                FootballField.createShapes(rankPositions, (int) (FootballField.END_ZONE_LENGTH * scaleFactor), 0, scaleFactor),
-                new HashMap<String, Shape>(),
-                new HashSet<String>(),
-                g,
-                (int) (FootballField.END_ZONE_LENGTH * scaleFactor),
-                0,
-                scaleFactor);
+    @Override 
+    public HashMap<String, RankPosition> getRankPositions() {
+        return this.rankPositions;
     }
-
-    public float getScaleFactor(){
-        return this.scaleFactor;
-    }
-
-//    public HashMap<String, RankPosition> getRankPositions() {
-//        return drillInfo.getMoves().get(currentMove).getEndPositions();
-//    }
 }


### PR DESCRIPTION
This pull request has a lot going on, so apologies for that. It's essentially the beginning of an overhaul of field rendering to replace `FootballField.java` with a more generic `FieldView` class (inherited and modified as needed per use case).  Here, we make `PdfImage` inherit from `FieldView`, then adjust the rendering to be both higher resolution and better quality by enabling interpolation & anti-aliasing.

The pull request can be broken down as follows:
- Commit 1 scales `drillHeight` in the PDF including the sideline width.
- Commits 2-4 add helper methods for both `Point` & `RankPosition` that will be helpful in the overhauled rendering code.
- Commit 5 adds the `FieldStyle` class, which contains all of the information needed for styling the appearance of the football field (colors, line thicknesses, etc.)
- Commit 6 adds `FieldView`, which re-implements a lot of `FootballField`, but dynamically scaling by units of on-field feet rather than hardcoded pixel sizes. The drill generated is tweaked slightly to be more readable (e.g. the grid lines are less obtrusive, the endzone & sideline margins are explicitly included), but overall it still looks mostly the same as the `FootballField` rendering.
- Commit 7 adds a comment about a mysterious 0.6ft error in the rank positioning. Added an issue to address that long-term: https://github.com/bigredbands/rank-panda/issues/42
- Commit 8 enables anti-aliasing, bilinear interpolation, and generally "nicer" rendering for the field.
- Commit 9 increases the resolution of the printed drill image in the PDF to 300dpi, making it much easier to read when printed.

### Future work
Other things I'm planning to do that will build off of this:
- Replace use of `FootballField` with `FieldView` in the move scrollbar & main drill editor.
- Add a "print greyscale" option to the PDF export.
- Allow users to persistently customize color settings for Rank Panda.

### Before
![image](https://github.com/user-attachments/assets/3a981267-8bf1-4d4e-8342-a1be7ed530b6)

### After
![image](https://github.com/user-attachments/assets/8fc5c1e7-2dff-4e1a-9b19-4c53c630e04a)
