### PR TITLE
PDFGenerator.java: fix instruction spacing

### DIFF
--- a/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
+++ b/src/main/java/org/bigredbands/mb/controllers/PDFGenerator.java
@@ -305,6 +305,7 @@ public class PDFGenerator {
                         contentStream.newLineAtOffset(-((numColumns - 1) * columnWidth), -nextRowOffset);
                         yPosition -= nextRowOffset;
                         newPage = false;
+                        maxLines = 1;
                     } else {
                         contentStream.newLineAtOffset(columnWidth, 0);
                     }


### PR DESCRIPTION
Reset the 'maxLines' variable, representing the longest drill instruction in a given row of three instructions, to 1 when moving to a new row. Without this reset, all instructions are spaced according to the longest drill instruction of the entire move, rather than the longest in the row.

### Before
![image](https://github.com/user-attachments/assets/9954447b-d911-4e66-b2e1-ba57e2abe230)

### After
![image](https://github.com/user-attachments/assets/dfc81384-2524-43ca-9d1a-f4fdfb1c8dbe)

