### PR TITLE
Moving transientRanks and most error dialogs to the views

### DIFF
--- a/src/main/java/org/bigredbands/mb/controllers/ControllerInterface.java
+++ b/src/main/java/org/bigredbands/mb/controllers/ControllerInterface.java
@@ -262,14 +262,23 @@ public interface ControllerInterface {
     public String mergeCommands(int[] commandIndices);
 
     /**
-     * Splits the specified command into two separate commands of the same type
-     * at the count specified
+     * Splits the specified command at the given index into two separate commands of
+     * the same type at the count specified. Updates the display afterwards.
      *
      * @param index - the index of command to be split
      * @param count - the count at which the command will be split
      * @return - An error message if one occurs
      */
     public String splitCommand(int index, int count);
+
+    /**
+     * Returns an error string if the command at the given index cannot be split.
+     * Otherwise, returns an empty string.
+     * 
+     * @param index - The index of the command to split.
+     * @return - An error string if the command at the given index cannot be split.
+     */
+    public String canSplit(int index);
 
     /**
      * Exports the project to a PDF file

--- a/src/main/java/org/bigredbands/mb/controllers/ControllerInterface.java
+++ b/src/main/java/org/bigredbands/mb/controllers/ControllerInterface.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 
 import org.bigredbands.mb.models.CommandPair;
+import org.bigredbands.mb.models.Move;
 import org.bigredbands.mb.models.RankPosition;
 
 /**
@@ -273,26 +274,18 @@ public interface ControllerInterface {
     public void setMoveComment(String comment);
 
     /**
-     * Returns the number of the current move
+     * Returns the number of the current move.
      *
-     * @return - the number of the current move
+     * @return - the number of the current move.
      */
-    public int getCurrentMove();
+    public int getCurrentMoveNumber();
 
     /**
-     * Returns additional indicators to be displayed to the user not stored as ranks
-     *
-     * @return - a hashmap mapping the name of the indicator to its position
+     * Returns the current move.
+     * 
+     * @return - the current move.
      */
-    public HashMap<String, RankPosition> getTransientRanks();
-
-    /**
-     * Adds a temporary indicator to show the user how the rank would look if drawn to
-     * the current position
-     *
-     * @param temporaryDrawingRank - the position of the indicator to be drawn
-     */
-    public void addTemporaryDrawingRank(RankPosition temporaryDrawingRank);
+    public Move getCurrentMove();
 
     public void updateInitialPosition(String rankName, RankPosition newPos);
 

--- a/src/main/java/org/bigredbands/mb/controllers/ControllerInterface.java
+++ b/src/main/java/org/bigredbands/mb/controllers/ControllerInterface.java
@@ -1,6 +1,7 @@
 package org.bigredbands.mb.controllers;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 
@@ -289,6 +290,15 @@ public interface ControllerInterface {
 
     public void updateInitialPosition(String rankName, RankPosition newPos);
 
-    void deleteMove(int moveNum);
+    public void deleteMove(int moveNum);
+
+    /**
+     * Gets the set of shared commands for the given rankNames and their commands.
+     * 
+     * @param rankNames - The rankNames for which to fetch shared commands.
+     * @param commands - The commands for which to fetch shared commands.
+     * @return An ArrayList containing the shared commands.
+     */
+    public ArrayList<CommandPair> getSharedCommands(HashSet<String> rankNames, HashMap<String, ArrayList<CommandPair>> commands);
 
 }

--- a/src/main/java/org/bigredbands/mb/controllers/ControllerInterface.java
+++ b/src/main/java/org/bigredbands/mb/controllers/ControllerInterface.java
@@ -61,12 +61,13 @@ public interface ControllerInterface {
     public boolean isModified();
 
     /**
-     * Adds a new rank to the models and update the view
+     * Adds a new rank to the models and update the view.
      *
-     * @param name - the name of the new rank
-     * @param rankPosition - the position of the new rank
+     * @param name - The name of the new rank
+     * @param rankPosition - The position of the new rank
+     * @return - An error messsge iff adding a rank failed.  An empty string otherwise.
      */
-    public void addRank(String name, RankPosition rankPosition);
+    public String addRank(String name, RankPosition rankPosition);
 
     /**
      * Adds a new move to the list of moves
@@ -109,22 +110,24 @@ public interface ControllerInterface {
     public void changeMoves(int targetMove);
 
     /**
-     * Assigns a command to the given rank in the current move. Displays an
+     * Assigns a command to the given rank in the current move. Returns an
      * error message if it could not add a command to the rank.
      *
-     * @param rankName
-     *            - the rank to add a command to
-     * @param commandPair
-     *            - the command and number of counts
+     * @param rankName    - the rank to add a command to
+     * @param commandPair - the command and number of counts
+     * @return - An error messsge iff assigning the command failed. An empty string
+     *         otherwise.
      */
-    public void assignCommand(String rankName, CommandPair commandPair);
+    public String assignCommand(String rankName, CommandPair commandPair);
 
     /**
-     * Sets the selected rank to the specified rank
+     * Sets the selected rank to the specified rank and updates the view.
      *
      * @param rankName - the rank name of the new selected rank
+     * @return - An error messsge iff setting the selected rank failed. An empty
+     *         string otherwise.
      */
-    public void addSelectedRank(String rankName, boolean reset);
+    public String addSelectedRank(String rankName, boolean reset);
 
     /**
      * Removes any current rank selection
@@ -160,11 +163,14 @@ public interface ControllerInterface {
             HashMap<Integer, Integer> countsHashMap, String songName);
 
     /**
-     * Removes the selected commands from the selected rank for the current move
+     * Removes the selected commands from the selected rank for the current move and
+     * updates the display.
      *
      * @param commandIndices - the index of commands to be removed
+     * @return - An error messsge iff removing the command failed. An empty string
+     *         otherwise.
      */
-    public void removeCommands(int[] commandIndices);
+    public String removeCommands(int[] commandIndices);
 
     /**
      * Gets the tempo changes throughout this song
@@ -214,34 +220,46 @@ public interface ControllerInterface {
     public HashMap<String, RankPosition> getPlaybackPositions();
 
     /**
-     * Rename the specified command to a new name, but keep the same functionality
+     * Renames the specified command to a new name, but keep the same functionality.
+     * Updates the display afterwards.
      *
      * @param index - the index of the command to be renamed
-     * @param name - the new name of the command
+     * @param name  - the new name of the command
+     * @return - An error messsge iff renaming the command failed. An empty string
+     *         otherwise.
      */
-    public void renameCommand(int index, String name);
+    public String renameCommand(int index, String name);
 
     /**
-     * Moves the specified commands up in the queue of commands
+     * Moves the specified commands up in the queue of commands. Updates the display
+     * afterwards.
      *
      * @param commandIndices - the indices of commands to be moved up
+     * @return - An error messsge iff moving the command failed. An empty string
+     *         otherwise.
      */
-    public void moveCommandsUp(int[] commandIndices);
+    public String moveCommandsUp(int[] commandIndices);
 
     /**
-     * Moves the specified commands down in the queue of commands
+     * Moves the specified commands down in the queue of commands. Updates the
+     * display afterwards.
      *
      * @param commandIndices - the indices of commands to be moved down
+     * @return - An error messsge iff moving the command failed. An empty string
+     *         otherwise.
      */
-    public void moveCommandsDown(int[] commandIndices);
+    public String moveCommandsDown(int[] commandIndices);
 
     /**
      * Merges the specified commands if they are of the same type
-     * into one command of their combined length
+     * into one command of their combined length.  Updates the
+     * display afterwards.
      *
      * @param commandIndices - the indices of commands to be merged
+     * @return - An error messsge iff merging the command failed. An empty string
+     *         otherwise.
      */
-    public void mergeCommands(int[] commandIndices);
+    public String mergeCommands(int[] commandIndices);
 
     /**
      * Splits the specified command into two separate commands of the same type

--- a/src/main/java/org/bigredbands/mb/controllers/MainController.java
+++ b/src/main/java/org/bigredbands/mb/controllers/MainController.java
@@ -285,7 +285,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
         drillInfo.addMove(counts, currentMove + 1);
         currentMove = currentMove + 1;
         if (!selectedRanks.isEmpty()) {
-            mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+            mainView.updateSelectedRank(selectedRanks);
         }
         modified = true;
         mainView.updateViewWithOneMove(drillInfo.getMoves().size() - 1, drillInfo.getMoves().get(drillInfo.getMoves().size() - 1).getCounts());
@@ -311,7 +311,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
         }
 
         if (!selectedRanks.isEmpty()) {
-            mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+            mainView.updateSelectedRank(selectedRanks);
         }
         modified = true;
         mainView.updateViewWithRemoveMove(currentMove, drillInfo.getMoves().get(currentMove).getCounts(),moveNum);
@@ -337,7 +337,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
         if (targetMove != currentMove) {
             currentMove = targetMove;
             if (!selectedRanks.isEmpty()) {
-                mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks, drillInfo.getMoves().get(currentMove).getCommands()));
+                mainView.updateSelectedRank(selectedRanks);
             }
             mainView.updateView(currentMove, drillInfo.getMoves().get(currentMove).getCounts());
         }
@@ -353,11 +353,10 @@ public class MainController implements ControllerInterface, SynchronizedControll
     public void addRank(String rankName, RankPosition rankPosition) {
         String errorMessage = drillInfo.addRankToMoves(rankName, rankPosition);
         if (errorMessage.isEmpty()) {
-            // TODO: maybe not clear? idk
             selectedRanks.clear();
             selectedRanks.add(rankName);
             modified = true;
-            mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+            mainView.updateSelectedRank(selectedRanks);
             mainView.updateView(currentMove, drillInfo.getMoves().get(currentMove).getCounts());
         }
         else {
@@ -371,7 +370,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
 
     }
 
-    private ArrayList<CommandPair> getSharedCommands(HashSet<String> rankNames, HashMap<String,ArrayList<CommandPair>>commands) {
+    public ArrayList<CommandPair> getSharedCommands(HashSet<String> rankNames, HashMap<String,ArrayList<CommandPair>>commands) {
         if(rankNames.size()==0) {
             return new ArrayList<CommandPair>();
         }
@@ -469,7 +468,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
         //TODO: may not be necessary later when you have to select ranks by clicking on them first
         selectedRanks.add(rankName);
         modified = true;
-        mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+        mainView.updateSelectedRank(selectedRanks);
         mainView.updateView(currentMove, drillInfo.getMoves().get(currentMove).getCounts());
     }
 
@@ -492,7 +491,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
             // } else {
             selectedRanks.add(rankName);
             // }
-            mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+            mainView.updateSelectedRank(selectedRanks);
             mainView.updateView(currentMove, drillInfo.getMoves().get(currentMove).getCounts());
         }
         else {
@@ -506,7 +505,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
      */
     public void deselectAll() {
         selectedRanks.clear();
-        mainView.updateSelectedRank(new HashSet<String>(), new ArrayList<CommandPair>());
+        mainView.clearSelectedRank();
         mainView.updateView(currentMove, drillInfo.getMoves().get(currentMove).getCounts());
     }
 
@@ -523,24 +522,21 @@ public class MainController implements ControllerInterface, SynchronizedControll
     /**
      * Deletes the specified rank
      *
-     * @param rankName - the name of the rank to be deleted
+     * @param rankNames - the names of the ranks to be deleted
      */
     @Override
-    public void deleteRank(HashSet<String>rankNames) {
+    public void deleteRank(HashSet<String> rankNames) {
         HashSet<String> oldSelectedRanks = (HashSet<String>)rankNames.clone();
 
         for(String rankName : oldSelectedRanks) {
             drillInfo.deleteRank(rankName);
             if (selectedRanks.contains(rankName)) {
                 selectedRanks.remove(rankName);
-                mainView.updateSelectedRank(new HashSet<String>(), new ArrayList<CommandPair>());
-            }
-            else {
-                mainView.updateSelectedRank(selectedRanks, drillInfo.getMoves().get(currentMove).getCommands().get(rankName));
             }
         }
 
         modified = true;
+        mainView.updateSelectedRank(selectedRanks);
         mainView.updateView(currentMove, drillInfo.getMoves().get(currentMove).getCounts());
     }
 
@@ -865,7 +861,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
             String errorMessage = drillInfo.getMoves().get(currentMove).renameCommand(rankName, rankIndex, name);
             if (errorMessage.isEmpty()) {
                 modified = true;
-                mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+                mainView.updateSelectedRank(selectedRanks);
             }
             else {
                 mainView.displayError(errorMessage);
@@ -912,7 +908,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
             String errorMessage = drillInfo.getMoves().get(currentMove).moveCommandsUp(rankName, rankIndices);
             if (errorMessage.isEmpty()) {
                 modified = true;
-                mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+                mainView.updateSelectedRank(selectedRanks);
             }
             else {
                 mainView.displayError(errorMessage);
@@ -959,7 +955,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
             String errorMessage = drillInfo.getMoves().get(currentMove).moveCommandsDown(rankName, rankIndices);
             if (errorMessage.isEmpty()) {
                 modified = true;
-                mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+                mainView.updateSelectedRank(selectedRanks);
             }
             else {
                 mainView.displayError(errorMessage);
@@ -1012,7 +1008,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
             String errorMessage = drillInfo.getMoves().get(currentMove).mergeCommands(rankName, rankIndices);
             if (errorMessage.isEmpty()) {
                 modified = true;
-                mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+                mainView.updateSelectedRank(selectedRanks);
             }
             else {
                 mainView.displayError(errorMessage);
@@ -1071,7 +1067,7 @@ public class MainController implements ControllerInterface, SynchronizedControll
             String errorMessage = drillInfo.getMoves().get(currentMove).splitCommand(rankName, rankIndex, count);
             if (errorMessage.isEmpty()) {
                 modified = true;
-                mainView.updateSelectedRank(selectedRanks, getSharedCommands(selectedRanks,drillInfo.getMoves().get(currentMove).getCommands()));
+                mainView.updateSelectedRank(selectedRanks);
             }
             else {
                 mainView.displayError(errorMessage);

--- a/src/main/java/org/bigredbands/mb/views/CommandListView.java
+++ b/src/main/java/org/bigredbands/mb/views/CommandListView.java
@@ -3,7 +3,6 @@ package org.bigredbands.mb.views;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Dialog.ModalityType;
-import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.util.ArrayList;
@@ -165,16 +164,21 @@ public class CommandListView {
         final int[] selectedIndices = commandJList.getSelectedIndices();
 
         if (selectedIndices.length > 0) {
+            final String canSplitErrorMessage = mainView.canSplit(selectedIndices[0]);
+            if (!canSplitErrorMessage.isEmpty()) {
+                mainView.displayError(canSplitErrorMessage);
+                return;
+            }
+
             final JDialog splitDialog = new JDialog(window, "Split Command");
-            splitDialog.setMinimumSize(new Dimension(350,180));
-            splitDialog.setSize(350,180);
+            splitDialog.setMinimumSize(new Dimension(350, 215));
+            splitDialog.setSize(350, 215);
             splitDialog.setAlwaysOnTop(true);
             splitDialog.setLocationRelativeTo(window);
             splitDialog.setModalityType(ModalityType.APPLICATION_MODAL);
 
             JPanel splitPanel = new JPanel();
             splitPanel.setLayout(new BoxLayout(splitPanel, BoxLayout.Y_AXIS));
-
 
             String splitText = "<html>You are splitting:<br /><br />" + listModel.get(selectedIndices[0]) + "<br /><br />Please specify the number of counts to split at.<br /><br /></html>";
             JLabel splitLabel = new JLabel("<html><div style=\"text-align: center;\">" + splitText + "</html>");
@@ -183,12 +187,11 @@ public class CommandListView {
             splitLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
 
             final JTextField countTextField = new JTextField();
-            countTextField.setPreferredSize(new Dimension(150,25));
-            countTextField.setMaximumSize(new Dimension(150,25));
+            countTextField.setPreferredSize(new Dimension(150, 25));
+            countTextField.setMaximumSize(new Dimension(150, 25));
 
             countTextField.setAlignmentX(Component.CENTER_ALIGNMENT);
 
-            final String warningText = "";
             final JLabel warningLabel = new JLabel("<html><div style=\"text-align: center;\"></html>");
 
             JPanel buttonPanel = new JPanel();
@@ -201,7 +204,7 @@ public class CommandListView {
                     String countString = countTextField.getText();
                     if (countString.equals("")) {
                         warningLabel.setText("Please specify rank name");
-//                        warningText = "Please specify rank name.";
+                        //warningText = "Please specify rank name.";
                         //splitDialog.setVisible(true);
                         return;
                     }

--- a/src/main/java/org/bigredbands/mb/views/ErrorDialog.java
+++ b/src/main/java/org/bigredbands/mb/views/ErrorDialog.java
@@ -13,7 +13,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 public class ErrorDialog {
-    public ErrorDialog(String errorMessage, JFrame window) {
+    public static void createErrorDialog(String errorMessage, JFrame window) {
         errorMessage = "<html><p>" + errorMessage + "</p></html>";
         final JDialog error = new JDialog(window, "Error");
         error.setSize(400,100);

--- a/src/main/java/org/bigredbands/mb/views/MainView.java
+++ b/src/main/java/org/bigredbands/mb/views/MainView.java
@@ -178,13 +178,31 @@ public class MainView implements ViewInterface {
     }
 
     /**
+     * Updates the selected rank text and the currently displayed commands on the screen.
+     * The commands for the given rank names are displayed.
+     *
+     * @param rankName - the rank name to display
+     */
+    @Override
+    public void updateSelectedRank(HashSet<String> rankNames) {
+        updateSelectedRank(rankNames, controller.getSharedCommands(rankNames, controller.getCurrentMove().getCommands()));
+    }
+
+    /**
+     * Clears the select rank text and the currently displayed commands on the screen.
+     */
+    @Override
+    public void clearSelectedRank() {
+        updateSelectedRank(new HashSet<String>(), new ArrayList<CommandPair>());
+    }
+
+    /**
      * Updates the selected rank text on the screen and the currently displayed commands.
      *
      * @param rankName - the rank name to display
      * @param commands - the commands to display in the command list.
      */
-    @Override
-    public void updateSelectedRank(HashSet<String>rankNames, ArrayList<CommandPair> commands) {
+    private void updateSelectedRank(HashSet<String> rankNames, ArrayList<CommandPair> commands) {
         project.updateSelectedRank(rankNames);
         project.updateCommandList(commands);
         updateProjectTitle();

--- a/src/main/java/org/bigredbands/mb/views/MainView.java
+++ b/src/main/java/org/bigredbands/mb/views/MainView.java
@@ -257,7 +257,10 @@ public class MainView implements ViewInterface {
         }
 
         for(String rankName : rankNames) {
-            controller.assignCommand(rankName,  newCommand);
+            final String errorMessage = controller.assignCommand(rankName,  newCommand);
+            if (!errorMessage.isEmpty()) {
+                displayError(errorMessage);
+            }
         }
         project.cancelPreviousCommand(type);
         return;
@@ -315,11 +318,16 @@ public class MainView implements ViewInterface {
     }
 
     /**
-     * Sets the currently selected rank
+     * Sets the currently selected rank and updates the view. In the event of an
+     * error, displays the error and does not set the selected rank.
+     * 
      * @param rankName - the currently selected rank
      */
     public void addSelectedRank(String rankName, boolean reset) {
-        controller.addSelectedRank(rankName,reset);
+        final String errorMessage = controller.addSelectedRank(rankName, reset);
+        if (!errorMessage.isEmpty()) {
+            displayError(errorMessage);
+        }
     }
 
     /**
@@ -435,12 +443,17 @@ public class MainView implements ViewInterface {
     }
 
     /**
-     * Add a rank to the project
+     * Adds a new rank to the models and update the view. In the event of an error,
+     * displays the error and does not add the rank.
+     * 
      * @param name - name of the rank
      * @param position - the position of the rank
      */
     public void addRank(String name, RankPosition position) {
-        controller.addRank(name, position);
+        final String errorMessage = controller.addRank(name, position);
+        if (!errorMessage.isEmpty()) {
+            displayError(errorMessage);
+        }
     }
 
     /**
@@ -449,7 +462,10 @@ public class MainView implements ViewInterface {
      * @param commandIndices - the indices of the commands to remove
      */
     public void removeCommands(int[] commandIndices) {
-        controller.removeCommands(commandIndices);
+        final String errorMessage = controller.removeCommands(commandIndices);
+        if (!errorMessage.isEmpty()) {
+            displayError(errorMessage);
+        }
     }
 
     /**
@@ -459,7 +475,10 @@ public class MainView implements ViewInterface {
      * @param name - the new name of the command
      */
     public void renameCommand(int index, String name) {
-        controller.renameCommand(index, name);
+        final String errorMessage = controller.renameCommand(index, name);
+        if (!errorMessage.isEmpty()) {
+            displayError(errorMessage);
+        }
     }
 
     /**
@@ -468,7 +487,10 @@ public class MainView implements ViewInterface {
      * @param commandIndices - the indices of commands to be moved up
      */
     public void moveCommandsUp(int[] commandIndices) {
-        controller.moveCommandsUp(commandIndices);
+        final String errorMessage = controller.moveCommandsUp(commandIndices);
+        if (!errorMessage.isEmpty()) {
+            displayError(errorMessage);
+        }
     }
 
     /**
@@ -477,7 +499,10 @@ public class MainView implements ViewInterface {
      * @param commandIndices - the indices of commands to be moved down
      */
     public void moveCommandsDown(int[] commandIndices) {
-        controller.moveCommandsDown(commandIndices);
+        final String errorMessage = controller.moveCommandsDown(commandIndices);
+        if (!errorMessage.isEmpty()) {
+            displayError(errorMessage);
+        }
     }
 
     /**
@@ -487,7 +512,10 @@ public class MainView implements ViewInterface {
      * @param commandIndices - the indices of commands to be merged
      */
     public void mergeCommands(int[] commandIndices) {
-        controller.mergeCommands(commandIndices);
+        final String errorMessage = controller.mergeCommands(commandIndices);
+        if (!errorMessage.isEmpty()) {
+            displayError(errorMessage);
+        }
     }
 
     /**

--- a/src/main/java/org/bigredbands/mb/views/MainView.java
+++ b/src/main/java/org/bigredbands/mb/views/MainView.java
@@ -517,7 +517,19 @@ public class MainView implements ViewInterface {
             displayError(errorMessage);
         }
     }
-
+    
+    /**
+     * Returns an error string if the command at the given index cannot be split.
+     * Otherwise, returns an empty string.
+     * 
+     * @param index - The index of the command to split.
+     * @return - An error string if the command at the given index cannot be split.
+     */
+    public String canSplit(int index) {
+        // Displaying the error message is handled by the split view logic
+        return controller.canSplit(index);
+    }
+    
     /**
      * Splits the specified command into two separate commands of the same type
      * at the count specified
@@ -527,6 +539,7 @@ public class MainView implements ViewInterface {
      * @return - An error message if one occurs
      */
     public String splitCommand(int index, int count) {
+        // Displaying the error message is handled by the split view logic
         return controller.splitCommand(index, count);
     }
 

--- a/src/main/java/org/bigredbands/mb/views/MainView.java
+++ b/src/main/java/org/bigredbands/mb/views/MainView.java
@@ -1,18 +1,17 @@
 package org.bigredbands.mb.views;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import javax.swing.JButton;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.filechooser.FileNameExtensionFilter;
 
 import org.bigredbands.mb.controllers.ControllerInterface;
 import org.bigredbands.mb.models.CommandPair;
+import org.bigredbands.mb.models.Move;
 import org.bigredbands.mb.models.RankPosition;
 import org.bigredbands.mb.exceptions.FileSelectionException;
 
@@ -570,27 +569,17 @@ public class MainView implements ViewInterface {
      *
      * @return - the number of the current move
      */
-    public int getCurrentMove() {
+    public int getCurrentMoveNumber() {
+        return controller.getCurrentMoveNumber();
+    }
+
+    /**
+     * Returns the current move.
+     * 
+     * @return - the current move.
+     */
+    public Move getCurrentMove() {
         return controller.getCurrentMove();
-    }
-
-    /**
-     * Returns additional indicators to be displayed to the user not stored as ranks
-     *
-     * @return - a hashmap mapping the name of the indicator to its position
-     */
-    public HashMap<String, RankPosition> getTransientRanks() {
-        return controller.getTransientRanks();
-    }
-
-    /**
-     * Adds a temporary indicator to show the user how the rank would look if drawn to
-     * the current position
-     *
-     * @param temporaryDrawingRank - the position of the indicator to be drawn
-     */
-    public void addTemporaryDrawingRank(RankPosition temporaryDrawingRank) {
-        controller.addTemporaryDrawingRank(temporaryDrawingRank);
     }
 
     /**

--- a/src/main/java/org/bigredbands/mb/views/MainView.java
+++ b/src/main/java/org/bigredbands/mb/views/MainView.java
@@ -269,7 +269,7 @@ public class MainView implements ViewInterface {
      * @param errorMessage - the error message to display
      */
     public void displayError(String errorMessage) {
-        new ErrorDialog(errorMessage, getCurrentWindow());
+        ErrorDialog.createErrorDialog(errorMessage, getCurrentWindow());
     }
 
     /**

--- a/src/main/java/org/bigredbands/mb/views/ProjectView.java
+++ b/src/main/java/org/bigredbands/mb/views/ProjectView.java
@@ -1090,7 +1090,7 @@ public class ProjectView {
         deleteMove.addActionListener(new ActionListener() {
             @Override
             public void actionPerformed(ActionEvent arg0) {
-                if(mainView.getCurrentMove()!=0) {
+                if(mainView.getCurrentMoveNumber()!=0) {
                     Object[] options = {"Yes", "No"};
                     int n = JOptionPane.showOptionDialog(getWindow(),
                             "Are you sure you want to delete this move?",
@@ -1100,7 +1100,7 @@ public class ProjectView {
                             null,
                             options,
                             options[0]);
-                    if (n==0) mainView.deleteMove(mainView.getCurrentMove());
+                    if (n==0) mainView.deleteMove(mainView.getCurrentMoveNumber());
                 }
             }
         });

--- a/src/main/java/org/bigredbands/mb/views/ViewInterface.java
+++ b/src/main/java/org/bigredbands/mb/views/ViewInterface.java
@@ -78,12 +78,16 @@ public interface ViewInterface {
 
     /**
      * Updates the selected rank text on the screen and the currently displayed commands.
+     * The commands for the given rank names are displayed.
      *
-     * @param rankNames - the rank names to display
-     * @param commands - the commands to display in the command list.
+     * @param rankName - the rank name to display
      */
-    void updateSelectedRank(HashSet<String> rankNames,
-            ArrayList<CommandPair> commands);
+    public void updateSelectedRank(HashSet<String> rankNames);
+
+    /**
+     * Clears the select rank text and the currently displayed commands on the screen.
+     */
+    public void clearSelectedRank();
 
     /**
      * Disables the listeners of the buttons in project view for playback

--- a/src/test/java/org/bigredbands/mb/controllers/MainControllerTest.java
+++ b/src/test/java/org/bigredbands/mb/controllers/MainControllerTest.java
@@ -3,7 +3,6 @@ package org.bigredbands.mb.controllers;
 import java.io.File;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Set;
 
 import org.bigredbands.mb.models.CommandPair;
 import org.bigredbands.mb.models.Point;
@@ -60,7 +59,7 @@ public class MainControllerTest {
         // initially set to false.
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-commands.pnd");
         mainController.loadProject(testFile);
-        mainController.addSelectedRank("A", true);
+        Assert.assertEquals("",  mainController.addSelectedRank("A", true));
         Assert.assertFalse(mainController.isModified());
     }
 
@@ -91,7 +90,8 @@ public class MainControllerTest {
         final MainController mainController = new MainController();
         mainController.initializeWithMainView(new FakeMainView());
         mainController.createEmptyProject();
-        mainController.addRank("rankName", new RankPosition(new Point(10, 10), new Point(10, 15)));
+        Assert.assertEquals("",
+                mainController.addRank("rankName", new RankPosition(new Point(10, 10), new Point(10, 15))));
         Assert.assertTrue(mainController.isModified());
     }
 
@@ -143,7 +143,7 @@ public class MainControllerTest {
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-no-commands.pnd");
         mainController.loadProject(testFile);
         mainController.changeMoves(1);
-        mainController.assignCommand("A", new CommandPair(CommandPair.MT, 4, "Mark Time"));
+        Assert.assertEquals("", mainController.assignCommand("A", new CommandPair(CommandPair.MT, 4, "Mark Time")));
         Assert.assertTrue(mainController.isModified());
     }
 
@@ -157,8 +157,8 @@ public class MainControllerTest {
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-commands.pnd");
         mainController.loadProject(testFile);
         mainController.changeMoves(1);
-        mainController.addSelectedRank("A", true);
-        mainController.removeCommands(new int[]{2});
+        Assert.assertEquals("",  mainController.addSelectedRank("A", true));
+        Assert.assertEquals("", mainController.removeCommands(new int[] { 2 }));
         Assert.assertTrue(mainController.isModified());
     }
 
@@ -172,8 +172,8 @@ public class MainControllerTest {
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-commands.pnd");
         mainController.loadProject(testFile);
         mainController.changeMoves(1);
-        mainController.addSelectedRank("A", true);
-        mainController.renameCommand(0, "This is the first command");
+        Assert.assertEquals("", mainController.addSelectedRank("A", true));
+        Assert.assertEquals("", mainController.renameCommand(0, "This is the first command"));
         Assert.assertTrue(mainController.isModified());
     }
 
@@ -187,8 +187,8 @@ public class MainControllerTest {
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-commands.pnd");
         mainController.loadProject(testFile);
         mainController.changeMoves(1);
-        mainController.addSelectedRank("A", true);
-        mainController.moveCommandsUp(new int[]{1});
+        Assert.assertEquals("", mainController.addSelectedRank("A", true));
+        Assert.assertEquals("", mainController.moveCommandsUp(new int[] { 1 }));
         Assert.assertTrue(mainController.isModified());
     }
 
@@ -202,8 +202,8 @@ public class MainControllerTest {
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-commands.pnd");
         mainController.loadProject(testFile);
         mainController.changeMoves(1);
-        mainController.addSelectedRank("A", true);
-        mainController.moveCommandsDown(new int[]{1});
+        Assert.assertEquals("", mainController.addSelectedRank("A", true));
+        Assert.assertEquals("", mainController.moveCommandsDown(new int[] { 1 }));
         Assert.assertTrue(mainController.isModified());
     }
 
@@ -214,11 +214,12 @@ public class MainControllerTest {
 
         // Loading a drill rather than creating an empty so that the modified field is
         // initially set to false.
-        final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-duplicate-commands.pnd");
+        final File testFile = new File(
+                "src/test/resources/MainController/two-moves-one-rank-with-duplicate-commands.pnd");
         mainController.loadProject(testFile);
         mainController.changeMoves(1);
-        mainController.addSelectedRank("A", true);
-        mainController.mergeCommands(new int[]{0, 1});
+        Assert.assertEquals("", mainController.addSelectedRank("A", true));
+        Assert.assertEquals("", mainController.mergeCommands(new int[] { 0, 1 }));
         Assert.assertTrue(mainController.isModified());
     }
 
@@ -232,7 +233,7 @@ public class MainControllerTest {
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-commands.pnd");
         mainController.loadProject(testFile);
         mainController.changeMoves(1);
-        mainController.addSelectedRank("A", true);
+        Assert.assertEquals("",  mainController.addSelectedRank("A", true));
         mainController.splitCommand(0, 4);
         Assert.assertTrue(mainController.isModified());
     }

--- a/src/test/java/org/bigredbands/mb/controllers/MainControllerTest.java
+++ b/src/test/java/org/bigredbands/mb/controllers/MainControllerTest.java
@@ -59,7 +59,7 @@ public class MainControllerTest {
         // initially set to false.
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-commands.pnd");
         mainController.loadProject(testFile);
-        Assert.assertEquals("",  mainController.addSelectedRank("A", true));
+        Assert.assertEquals("", mainController.addSelectedRank("A", true));
         Assert.assertFalse(mainController.isModified());
     }
 
@@ -157,7 +157,7 @@ public class MainControllerTest {
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-commands.pnd");
         mainController.loadProject(testFile);
         mainController.changeMoves(1);
-        Assert.assertEquals("",  mainController.addSelectedRank("A", true));
+        Assert.assertEquals("", mainController.addSelectedRank("A", true));
         Assert.assertEquals("", mainController.removeCommands(new int[] { 2 }));
         Assert.assertTrue(mainController.isModified());
     }
@@ -233,8 +233,8 @@ public class MainControllerTest {
         final File testFile = new File("src/test/resources/MainController/two-moves-one-rank-with-commands.pnd");
         mainController.loadProject(testFile);
         mainController.changeMoves(1);
-        Assert.assertEquals("",  mainController.addSelectedRank("A", true));
-        mainController.splitCommand(0, 4);
+        Assert.assertEquals("", mainController.addSelectedRank("A", true));
+        Assert.assertEquals("", mainController.splitCommand(0, 4));
         Assert.assertTrue(mainController.isModified());
     }
 }

--- a/src/test/java/org/bigredbands/mb/utils/FakeMainView.java
+++ b/src/test/java/org/bigredbands/mb/utils/FakeMainView.java
@@ -1,10 +1,8 @@
 package org.bigredbands.mb.utils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import org.bigredbands.mb.models.CommandPair;
 import org.bigredbands.mb.models.RankPosition;
 import org.bigredbands.mb.views.ViewInterface;
 
@@ -52,7 +50,12 @@ public class FakeMainView implements ViewInterface {
     }
 
     @Override
-    public void updateSelectedRank(HashSet<String> rankNames, ArrayList<CommandPair> commands) {
+    public void updateSelectedRank(HashSet<String> rankNames) {
+        // No-op
+    }
+
+    @Override
+    public void clearSelectedRank() {
         // No-op
     }
 


### PR DESCRIPTION
This pull request continues the incremental process of splitting the circular dependency between the views and the controllers.  Specifically:

* It moves transientRanks into the FootballField class, as they are only used to draw in-progress ranks and do not impact any of the drill.
* It moves most error dialogs into the views.  The saving, loading, and PDF generation error dialogs will possibly need additional refactoring in order to cleanly move them.

Once all error dialogs are moved to the view, the remaining logic that needs to be moved out of the controller is primarily the update methods.  Along that line, this pull request also changes the inputs to updateSelectedRank to allow for similar refactoring in the future.