### PR TITLE
Improve appearance of drill move scrollbar

### DIFF
--- a/src/main/java/org/bigredbands/mb/views/MoveScrollBar.java
+++ b/src/main/java/org/bigredbands/mb/views/MoveScrollBar.java
@@ -1,9 +1,8 @@
 package org.bigredbands.mb.views;
 
 import java.awt.Color;
+import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.event.MouseEvent;
-import java.awt.event.MouseListener;
 import java.util.ArrayList;
 
 import javax.swing.Box;
@@ -14,17 +13,17 @@ import javax.swing.JScrollPane;
 import javax.swing.border.LineBorder;
 
 import org.bigredbands.mb.controllers.ControllerInterface;
+import org.bigredbands.mb.models.Field;
 
 public class MoveScrollBar {
 
-    private MainView mainView;
+    private ControllerInterface controller;
 
     private JScrollPane moveScrollPane;
     private JPanel moveContainer;
 
     private final int THUMBNAIL_WIDTH = 131; //Sweet spot that no horizontal scroll bar is needed
-    //private final Dimension MOVE_THUMBNAIL_SIZE = new Dimension(THUMBNAIL_WIDTH, (int)(THUMBNAIL_WIDTH * (FootballField.FIELD_HEIGHT/FootballField.FIELD_LENGTH)));  //without end zones
-    private final Dimension MOVE_THUMBNAIL_SIZE = new Dimension(THUMBNAIL_WIDTH, (int)(THUMBNAIL_WIDTH * (1.0f/FootballField.WIDTH_TO_HEIGHT_RATIO)));  //with end zones
+    private final Dimension MOVE_THUMBNAIL_SIZE = new Dimension(THUMBNAIL_WIDTH, THUMBNAIL_WIDTH);
 
     private final Dimension MOVE_THUMBNAIL_MARGIN = new Dimension(0,20);
 
@@ -32,12 +31,12 @@ public class MoveScrollBar {
 
     private final Dimension MOVE_LABEL_SIZE = new Dimension(10, 20);
 
-    private ArrayList<FootballField> thumbnailList = new ArrayList<FootballField>();
+    private ArrayList<MoveThumbnail> thumbnailList = new ArrayList<MoveThumbnail>();
 
     private ArrayList<JPanel> moveComponentList = new ArrayList<JPanel>();
 
-    public MoveScrollBar(MainView main) {
-        this.mainView = main;
+    public MoveScrollBar(ControllerInterface controller) {
+        this.controller = controller;
 
         //create the jscrollpane
         moveScrollPane = new JScrollPane();
@@ -98,96 +97,39 @@ public class MoveScrollBar {
     }
 
     public void repaintScrollBar() {
-        for (FootballField move : thumbnailList) {
+        for (MoveThumbnail move : thumbnailList) {
             move.repaint();
         }
     }
 
     private void addMove(final int moveNumber) {
-        /*JButton moveButton = new JButton("Move " + moveNumber);
-        moveButton.setAlignmentX(0.5f);
-        moveButton.setPreferredSize(MOVE_THUMBNAIL_SIZE);
-        moveButton.addActionListener(new ActionListener() {
-            @Override
-            public void actionPerformed(ActionEvent arg0) {
-                controller.changeMoves(moveNumber);
-            }
-        });
-        moveContainer.add(moveButton);*/
-        //MoveThumbnail moveThumbnail = new MoveThumbnail(mainView, ((float)THUMBNAIL_WIDTH)/((float) (FootballField.FIELD_LENGTH + 2*FootballField.END_ZONE_LENGTH)), MOVE_THUMBNAIL_SIZE, moveNumber);
-        FootballField moveThumbnail = new FootballField(mainView, moveNumber);
-        //Center the moveThumbnail
-        moveThumbnail.setAlignmentX(0.5f);
-
-        //Ensure the moveThumbnail is properly sized
-        moveThumbnail.setPreferredSize(MOVE_THUMBNAIL_SIZE);
-        moveThumbnail.setMaximumSize(MOVE_THUMBNAIL_SIZE);
-
-        //Set up the listener for the moveThumbnail
-        moveThumbnail.addMouseListener(new MouseListener() {
-
-            @Override
-            public void mouseClicked(MouseEvent arg0) {
-                // TODO: NOPE
-                mainView.changeMoves(moveNumber);
-            }
-
-            public void mouseEntered(MouseEvent arg0) {}
-
-            public void mouseExited(MouseEvent arg0) {}
-
-            public void mousePressed(MouseEvent arg0) {}
-
-            public void mouseReleased(MouseEvent arg0) {}
-        });
         JPanel oneMoveContainer = new JPanel();
-        oneMoveContainer.setLayout(new BoxLayout(oneMoveContainer,BoxLayout.Y_AXIS));
+        oneMoveContainer.setLayout(new BoxLayout(oneMoveContainer, BoxLayout.Y_AXIS));
+        oneMoveContainer.setAlignmentX(Component.CENTER_ALIGNMENT);
+
+        MoveThumbnail moveThumbnail = new MoveThumbnail(Field.CollegeFootball, controller, moveNumber);
+        moveThumbnail.setPreferredSize(MOVE_THUMBNAIL_SIZE);
+        moveThumbnail.setAlignmentX(Component.CENTER_ALIGNMENT);
         oneMoveContainer.add(moveThumbnail);
+
         oneMoveContainer.add(Box.createRigidArea(MOVE_LABEL_MARGIN));
+
         JLabel moveLabel = new JLabel("Move " + moveNumber);
-        moveLabel.setAlignmentX(0.5f);
+        moveLabel.setAlignmentX(Component.CENTER_ALIGNMENT);
         oneMoveContainer.add(moveLabel);
 
-        //Space between moveThumbnails, this is necessary so they don't press up against each other
+        // Space between moveThumbnails, this is necessary so they don't press
+        // up against each other
         oneMoveContainer.add(Box.createRigidArea(MOVE_THUMBNAIL_MARGIN));
 
         moveContainer.add(oneMoveContainer);
         if(moveComponentList.size() > moveNumber) {
-            moveComponentList.set(moveNumber,oneMoveContainer);
-            thumbnailList.set(moveNumber,moveThumbnail);
+            moveComponentList.set(moveNumber, oneMoveContainer);
+            thumbnailList.set(moveNumber, moveThumbnail);
         } else {
-            moveComponentList.add(moveNumber,oneMoveContainer);
-            thumbnailList.add(moveNumber,moveThumbnail);
+            moveComponentList.add(moveNumber, oneMoveContainer);
+            thumbnailList.add(moveNumber, moveThumbnail);
         }
-
-        /*FootballField footballField = new FootballField(mainView);
-        footballField.setAlignmentX(0.5f);
-        footballField.setPreferredSize(MOVE_THUMBNAIL_SIZE);
-        footballField.addMouseListener(new MouseListener() {
-
-            @Override
-            public void mouseClicked(MouseEvent arg0) {
-                mainView.changeMoves(moveNumber);
-            }
-
-            @Override
-            public void mouseEntered(MouseEvent arg0) {
-            }
-
-            @Override
-            public void mouseExited(MouseEvent arg0) {
-            }
-
-            @Override
-            public void mousePressed(MouseEvent arg0) {
-            }
-
-            @Override
-            public void mouseReleased(MouseEvent arg0) {
-            }
-        });
-        moveContainer.add(footballField);
-        thumbnailList.add(footballField);*/
     }
 
     private void deleteMove(final int moveNumber) {

--- a/src/main/java/org/bigredbands/mb/views/MoveThumbnail.java
+++ b/src/main/java/org/bigredbands/mb/views/MoveThumbnail.java
@@ -1,35 +1,82 @@
 package org.bigredbands.mb.views;
 
 import java.awt.Color;
-import java.awt.Dimension;
-import java.awt.Graphics;
+import java.awt.event.MouseListener;
+import java.util.HashMap;
 
-import javax.swing.JPanel;
+import org.bigredbands.mb.controllers.ControllerInterface;
+import org.bigredbands.mb.models.Field;
+import org.bigredbands.mb.models.RankPosition;
+import java.awt.event.MouseEvent;
 
-public class MoveThumbnail extends JPanel {
+public class MoveThumbnail extends FieldView {
 
-    private float scaleFactor;
-    private Dimension containingDimension;
-    private MainView mainView;
-    private int moveNumber;
+    private final ControllerInterface controller;
+    private final int moveNumber;
 
-    public MoveThumbnail(MainView mainView, float scaleFactor, Dimension containingDimension, int moveNumber) {
-        super();
-        this.scaleFactor = scaleFactor;
-        this.containingDimension = containingDimension;
-        this.mainView = mainView;
+    public MoveThumbnail(Field field, ControllerInterface controller, int moveNumber) {
+        super(field);
+        this.controller = controller;
         this.moveNumber = moveNumber;
+        this.setFieldStyle(new ThumbnailFieldStyle(controller, moveNumber));
+
+        // TODO: should this be set up in the parent view?
+        addMouseListener(new MouseListener() {
+            @Override
+            public void mouseClicked(MouseEvent arg0) {
+                controller.changeMoves(moveNumber);
+            }
+
+            @Override
+            public void mouseEntered(MouseEvent arg0) {}
+
+            @Override
+            public void mouseExited(MouseEvent arg0) {}
+
+            @Override
+            public void mousePressed(MouseEvent arg0) {}
+
+            @Override
+            public void mouseReleased(MouseEvent arg0) {}
+        });
     }
 
     @Override
-    public void paintComponent(Graphics g) {
-        super.paintComponent(g);
-        g.setColor(Color.WHITE);
-        g.fillRect(0, 0, (int) ((FootballField.FIELD_LENGTH + 2*FootballField.END_ZONE_LENGTH) * scaleFactor), (int) (FootballField.FIELD_HEIGHT * scaleFactor));
+    public HashMap<String, RankPosition> getRankPositions() {
+        return controller.getRankPositions(moveNumber);
+    }
 
-        g.setColor(Color.BLACK);
-        //FootballField.drawFieldLines(g, this.getSize(), 0, 0, 0);
-        //FootballField.drawHashes(g, (int) (FootballField.END_ZONE_LENGTH * scaleFactor), 0, scaleFactor);
-        //FootballField.drawRanks(mainView.getRankPositions(moveNumber), mainView.getSelectedRank(), g, (int) (FootballField.END_ZONE_LENGTH * scaleFactor), 0, scaleFactor);
+    private class ThumbnailFieldStyle extends FieldStyle {
+        private final ControllerInterface controller;
+        private final int moveNumber;
+
+        private ThumbnailFieldStyle(ControllerInterface controller, int moveNumber) {
+            super();
+            this.controller = controller;
+            this.moveNumber = moveNumber;
+        }
+
+        @Override
+        public Color getBackgroundColor() {
+            if (controller.getCurrentMoveNumber() == moveNumber) {
+                return new Color(0, 0, 255, 100);
+            } else {
+                return super.getBackgroundColor();
+            }
+        }
+
+        // Only render the major field lines
+        @Override
+        public float getGridWidth() { return 0; }
+
+        @Override
+        public float getMinorIncrementWidth() { return 0; }
+
+        // Render ranks larger, don't show rank names
+        @Override
+        public float getRankStrokeWidth() { return 4.0f; }
+
+        @Override
+        public Color getRankLabelColor() { return new Color(0, 0, 0, 0); }
     }
 }

--- a/src/main/java/org/bigredbands/mb/views/MoveThumbnail.java
+++ b/src/main/java/org/bigredbands/mb/views/MoveThumbnail.java
@@ -34,7 +34,9 @@ public class MoveThumbnail extends FieldView {
             public void mouseExited(MouseEvent arg0) {}
 
             @Override
-            public void mousePressed(MouseEvent arg0) {}
+            public void mousePressed(MouseEvent arg0) {
+                controller.changeMoves(moveNumber);
+            }
 
             @Override
             public void mouseReleased(MouseEvent arg0) {}

--- a/src/main/java/org/bigredbands/mb/views/ProjectView.java
+++ b/src/main/java/org/bigredbands/mb/views/ProjectView.java
@@ -1108,7 +1108,7 @@ public class ProjectView {
         testPanel.add(deleteMove);
 
         // initialize and create the side scrollbar
-        moveScrollBar = new MoveScrollBar(mainView);
+        moveScrollBar = new MoveScrollBar(controller);
         moveScrollBar.createNewScrollBar(mainView.getNumberOfMoves());
         rightHolder.add(moveScrollBar.getScrollPane(), BorderLayout.CENTER);
 


### PR DESCRIPTION
As it is now, the drill scrollbar is fairly useless; with just a handful of ranks, it's an unreadable blob of blue and red. This pull request updates the `MoveScrollbar` class to use the `MoveThumbnail` class to represent the drill thumbnail, which itself is updated to extend `FieldView`, similar to how `PdfImage` was updated in https://github.com/bigredbands/rank-panda/pull/41.

Before:
![image](https://github.com/user-attachments/assets/727867f9-aba0-4be1-9f15-e8a9233127ca)

After:
TODO (need to make thumbnail alignment work properly)